### PR TITLE
Add exec wrapper for java agent too.

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -10,8 +10,8 @@ Two types of layers are provided
 
 The [OpenTelemetry Java Agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
 is bundled into the base of the layer and can be loaded into a Lambda function by specifying the
-environment variable `JAVA_TOOL_OPTIONS=-javaagent:/opt/opentelemetry-javaagent.jar` in your Lambda
-configuration. The agent will automatically instrument your application for all supported libraries.
+`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` in your Lambda configuration. The agent will be automatically
+loaded and instrument your application for all supported libraries.
 
 Note, automatic instrumentation has a notable impact on startup time on AWS Lambda and you will
 generally need to use this along with provisioned concurrency and warmup requests to serve production

--- a/java/layer-javaagent/build.gradle.kts
+++ b/java/layer-javaagent/build.gradle.kts
@@ -14,6 +14,8 @@ tasks {
         from(configurations["runtimeClasspath"]) {
             rename("opentelemetry-javaagent-.*.jar", "opentelemetry-javaagent.jar")
         }
+
+        from("scripts")
     }
 
     val assemble by existing {

--- a/java/layer-javaagent/scripts/otel-handler
+++ b/java/layer-javaagent/scripts/otel-handler
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export JAVA_TOOL_OPTIONS="-javaagent:/opt/opentelemetry-javaagent.jar ${JAVA_TOOL_OPTIONS}"
+
+exec "$@"

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -2,6 +2,6 @@
 
 echo "$@"
 
-export NODE_OPTIONS="--require /opt/wrapper.js"
+export NODE_OPTIONS="--require /opt/wrapper.js ${NODE_OPTIONS}"
 
 exec "$@"


### PR DESCRIPTION
While UX of adding java_tool_options isn't much worse than exec wrapper, it makes things more consistent for wrapper vs agent version and gives us flexibility if we need to do anything crazy in the wrapper in the future.

Also fixes node wrapper to not lose user NODE_OPTIONS