### PR TITLE
Remove prometheusexporter

### DIFF
--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -6,7 +6,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
-	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
@@ -24,7 +23,6 @@ func Components() (
 	}
 
 	exporters, err := component.MakeExporterFactoryMap(
-		prometheusexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),


### PR DESCRIPTION
Based on earlier discussion, we decided to keep the default components
OTLP based. Each distro can extend it with vendor specific components.
I'm keeping the loggingexporter for debugging reasons.