### PR TITLE
Remove println

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -52,7 +52,7 @@ func NewInProcessCollector(factories component.Factories) *InProcessCollector {
 
 func envLoaderConfigFactory(v *viper.Viper, factories component.Factories) (*configmodels.Config, error) {
 	if configContent, ok := os.LookupEnv("OPENTELEMETRY_COLLECTOR_CONFIG_CONTENT"); ok {
-		println("Reading config from environment: ", configContent)
+		logln("Reading config from environment: ", configContent)
 		configContent = strings.Replace(configContent, "\\n", "\n", -1)
 		var configBytes = []byte(configContent)
 		err := v.ReadConfig(bytes.NewBuffer(configBytes))
@@ -62,7 +62,7 @@ func envLoaderConfigFactory(v *viper.Viper, factories component.Factories) (*con
 		return config.Load(v, factories)
 	}
 
-	println("Reading config from file: ", configFile)
+	logln("Reading config from file: ", configFile)
 	file := configFile
 	if file == "" {
 		return nil, errors.New("config file not specified")

--- a/collector/main.go
+++ b/collector/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -16,11 +14,11 @@ import (
 var (
 	extensionName   = filepath.Base(os.Args[0]) // extension name has to match the filename
 	extensionClient = extension.NewClient(os.Getenv("AWS_LAMBDA_RUNTIME_API"))
-	printPrefix     = fmt.Sprintf("[%s]", extensionName)
 )
 
 func main() {
-	fmt.Println("Launching Opentelemetry Lambda extension, version: ", Version)
+	logln("Launching Opentelemetry Lambda extension, version: ", Version)
+
 	factories, _ := lambdacomponents.Components()
 	collector := NewInProcessCollector(factories)
 	collector.prepareConfig()
@@ -33,15 +31,15 @@ func main() {
 	go func() {
 		s := <-sigs
 		cancel()
-		println(printPrefix, "Received", s)
-		println(printPrefix, "Exiting")
+		logln("Received", s)
+		logln("Exiting")
 	}()
 
 	res, err := extensionClient.Register(ctx, extensionName)
 	if err != nil {
 		panic(err)
 	}
-	println(printPrefix, "Register response:", prettyPrint(res))
+	logln("Register response:", prettyPrint(res))
 
 	// Will block until shutdown event is received or cancelled via the context.
 	processEvents(ctx, collector)
@@ -53,29 +51,22 @@ func processEvents(ctx context.Context, collector *InProcessCollector) {
 		case <-ctx.Done():
 			return
 		default:
-			println(printPrefix, "Waiting for event...")
+			logln("Waiting for event...")
 			res, err := extensionClient.NextEvent(ctx)
 			if err != nil {
-				println(printPrefix, "Error:", err)
-				println(printPrefix, "Exiting")
+				logln("Error:", err)
+				logln("Exiting")
 				return
 			}
-			println(printPrefix, "Received event:", prettyPrint(res))
+
+			logln("Received event:", prettyPrint(res))
 			// Exit if we receive a SHUTDOWN event
 			if res.EventType == extension.Shutdown {
 				collector.stop() // TODO: handle return values
-				println(printPrefix, "Received SHUTDOWN event")
-				println(printPrefix, "Exiting")
+				logln("Received SHUTDOWN event")
+				logln("Exiting")
 				return
 			}
 		}
 	}
-}
-
-func prettyPrint(v interface{}) string {
-	data, err := json.MarshalIndent(v, "", "\t")
-	if err != nil {
-		return ""
-	}
-	return string(data)
 }

--- a/collector/print.go
+++ b/collector/print.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+var logPrefix = fmt.Sprintf("[%s]", extensionName)
+
+func prettyPrint(v interface{}) string {
+	data, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func logln(a ...interface{}) {
+	// TODO(jbd): When allocation here is a problem,
+	// replace log with zap.
+	args := []interface{}{logPrefix}
+	args = append(args, a...)
+	log.Println(args...)
+}


### PR DESCRIPTION
println is a built in not guranteed to stay in language. Introduce
logln to log with the component name consistently. If additional
allocation becomes a problem (not very likely), we can consider moving
to zap.