### PR TITLE
Minor readability improvements

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -15,11 +15,13 @@ import (
 	"go.opentelemetry.io/collector/service"
 )
 
-// Version variable will be replaced at link time after `make` has been run.
-var Version = "latest"
+var (
+	// Version variable will be replaced at link time after `make` has been run.
+	Version = "latest"
 
-// GitHash variable will be replaced at link time after `make` has been run.
-var GitHash = "<NOT PROPERLY GENERATED>"
+	// GitHash variable will be replaced at link time after `make` has been run.
+	GitHash = "<NOT PROPERLY GENERATED>"
+)
 
 // InProcessCollector implements the OtelcolRunner interfaces running a single otelcol as a go routine within the
 // same process as the test executor.
@@ -31,9 +33,7 @@ type InProcessCollector struct {
 	stopped   bool
 }
 
-var (
-	configFile = getConfig()
-)
+var configFile = getConfig()
 
 func getConfig() string {
 	val, ex := os.LookupEnv("OPENTELEMETRY_COLLECTOR_CONFIG_FILE")

--- a/collector/extension/client.go
+++ b/collector/extension/client.go
@@ -49,7 +49,9 @@ const (
 
 	// Shutdown is a shutdown event for the environment
 	Shutdown EventType = "SHUTDOWN"
+)
 
+const (
 	extensionNameHeader      = "Lambda-Extension-Name"
 	extensionIdentiferHeader = "Lambda-Extension-Identifier"
 	extensionErrorType       = "Lambda-Extension-Function-Error-Type"

--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -10,10 +10,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
-func Components() (
-	component.Factories,
-	error,
-) {
+func Components() (component.Factories, error) {
 	var errs []error
 
 	receivers, err := component.MakeReceiverFactoryMap(


### PR DESCRIPTION
In Go, group the vars/const together if they need to be grouped.
Grouping is not used if there is one item. Removing the newlines
from the function signature as well.