### PR TITLE
Remove stopped return value from InProcessCollecor.stop

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -142,12 +142,11 @@ func (ipp *InProcessCollector) start() error {
 	return err
 }
 
-func (ipp *InProcessCollector) stop() (stopped bool, err error) {
+func (ipp *InProcessCollector) stop() error {
 	if !ipp.stopped {
 		ipp.stopped = true
 		ipp.svc.Shutdown()
 	}
 	<-ipp.appDone
-	stopped = ipp.stopped
-	return stopped, err
+	return nil
 }


### PR DESCRIPTION
stop will always return true for stopped. Removing it
from the function. There is no way stop can return an error
now but keeping it in case we need to do thing that returns
an error in the future.