### PR TITLE
Add terraform deployment for python.

### DIFF
--- a/python/integration-tests/function/main.tf
+++ b/python/integration-tests/function/main.tf
@@ -1,0 +1,22 @@
+resource "aws_lambda_layer_version" "opentelemetry_python_wrapper" {
+  layer_name          = var.sdk_layer_name
+  filename            = "../../src/build/layer.zip"
+  compatible_runtimes = ["python3.8"]
+  license_info        = "Apache-2.0"
+  source_code_hash    = filebase64sha256("../../src/build/layer.zip")
+}
+
+resource "aws_lambda_layer_version" "opentelemetry_collector" {
+  layer_name          = var.collector_layer_name
+  filename            = "../../../collector/build/collector-extension.zip"
+  compatible_runtimes = ["nodejs10.x", "nodejs12.x", "nodejs14.x"]
+  license_info        = "Apache-2.0"
+  source_code_hash    = filebase64sha256("../../../collector/build/collector-extension.zip")
+}
+
+module "function" {
+  source                   = "../../sample-apps/deploy"
+  name                     = var.function_name
+  collector_layer_arn      = aws_lambda_layer_version.opentelemetry_collector.arn
+  python_wrapper_layer_arn = aws_lambda_layer_version.opentelemetry_python_wrapper.arn
+}

--- a/python/integration-tests/function/outputs.tf
+++ b/python/integration-tests/function/outputs.tf
@@ -1,0 +1,3 @@
+output "api-gateway-url" {
+  value = module.function.api-gateway-url
+}

--- a/python/integration-tests/function/variables.tf
+++ b/python/integration-tests/function/variables.tf
@@ -1,0 +1,17 @@
+variable "collector_layer_name" {
+  type        = string
+  description = "Name of published collector layer"
+  default     = "opentelemetry-collector"
+}
+
+variable "sdk_layer_name" {
+  type        = string
+  description = "Name of published SDK layer"
+  default     = "opentelemetry-java-wrapper"
+}
+
+variable "function_name" {
+  type        = string
+  description = "Name of sample app function / API gateway"
+  default     = "hello-python"
+}

--- a/python/sample-apps/build.sh
+++ b/python/sample-apps/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p build/python
+pip3 install -r function/requirements.txt -t build/python
+cp function/lambda_function.py -t build/python
+cd build/python || exit
+zip -r ../function.zip *

--- a/python/sample-apps/deploy/main.tf
+++ b/python/sample-apps/deploy/main.tf
@@ -1,0 +1,43 @@
+module "function" {
+  source = "terraform-aws-modules/lambda/aws"
+
+  function_name = var.name
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.8"
+
+  create_package         = false
+  local_existing_package = "${path.module}/../build/function.zip"
+
+  memory_size = 384
+  timeout     = 20
+
+  layers = [
+    var.collector_layer_arn,
+    var.python_wrapper_layer_arn
+  ]
+
+  environment_variables = {
+    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-instrument"
+  }
+
+  attach_policy_statements = true
+  policy_statements = {
+    s3 = {
+      effect = "Allow"
+      actions = [
+        "s3:ListAllMyBuckets"
+      ]
+      resources = [
+        "*"
+      ]
+    }
+  }
+}
+
+module "api-gateway" {
+  source = "../../../utils/terraform/api-gateway-proxy"
+
+  name                = var.name
+  function_name       = module.function.this_lambda_function_name
+  function_invoke_arn = module.function.this_lambda_function_invoke_arn
+}

--- a/python/sample-apps/deploy/outputs.tf
+++ b/python/sample-apps/deploy/outputs.tf
@@ -1,0 +1,3 @@
+output "api-gateway-url" {
+  value = module.api-gateway.api_gateway_url
+}

--- a/python/sample-apps/deploy/variables.tf
+++ b/python/sample-apps/deploy/variables.tf
@@ -1,0 +1,17 @@
+variable "name" {
+  type        = string
+  description = "Name of created function and API Gateway"
+  default     = "hello-python"
+}
+
+variable "collector_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry collector extension"
+  // TODO(anuraaga): Add default when a public layer is published.
+}
+
+variable "python_wrapper_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry Python Wrapper"
+  // TODO(anuraaga): Add default when a public layer is published.
+}

--- a/python/src/build.sh
+++ b/python/src/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+mkdir -p build
+docker build -t aws-otel-lambda-python-layer otel
+docker run -it --rm -v "$(pwd)/build:/out" aws-otel-lambda-python-layer

--- a/python/src/otel/Dockerfile
+++ b/python/src/otel/Dockerfile
@@ -1,0 +1,22 @@
+ARG runtime=python3.8
+
+FROM public.ecr.aws/sam/build-${runtime}
+
+ADD . /workspace
+
+WORKDIR /workspace
+
+RUN mkdir -p /build && \
+  pip3 install -r otel_sdk/requirements.txt -t /build/python && \
+  pip3 install -r otel_sdk/requirements-nodeps.txt -t /build/tmp --no-deps && \
+  cp -r /build/tmp/* /build/python/ && \
+  rm -rf /build/tmp && \
+  cp -r otel_sdk/* /build/python && \
+  mv /build/python/otel-instrument /build/otel-instrument && \
+  chmod 755 /build/otel-instrument && \
+  rm -rf /build/python/boto* && \
+  rm -rf /build/python/urllib3* && \
+  cd /build && \
+  zip -r layer.zip otel-instrument python
+
+CMD cp /build/layer.zip /out/layer.zip


### PR DESCRIPTION
This only adds files so doesn't interfere with current sam approach. But I think having a terraform config for python may be helpful when finishing out tests.