### PR TITLE
Add an extensions folder that is packaged into wrapper jar which can …

### DIFF
--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -23,6 +23,11 @@ tasks {
             into("java/lib")
         }
 
+        // Can be used by redistributions of the wrapper to add more libraries.
+        from("build/extensions") {
+            into("java/lib")
+        }
+
         from("scripts")
     }
 


### PR DESCRIPTION
…be used by distributions.

This seems like the simplest way to extend the Java wrapper, as most customization should just be JARs that implement SPI interfaces. The JARs can be added into this folder before building the layer.