### PR TITLE
Reformat imports

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -16,12 +16,13 @@ package main
 
 import (
 	"fmt"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/service"
-	"go.opentelemetry.io/collector/service/parserprovider"
 	"io"
 	"log"
 	"os"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service"
+	"go.opentelemetry.io/collector/service/parserprovider"
 )
 
 var (


### PR DESCRIPTION
Per Go style, standard library imports should be seperated from other imports.