### PR TITLE
Move Collector to its own package

### DIFF
--- a/collector/lambdacollector/collector.go
+++ b/collector/lambdacollector/collector.go
@@ -12,24 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package lambdacollector
 
 import (
 	"fmt"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/service"
-	"go.opentelemetry.io/collector/service/parserprovider"
 	"io"
 	"log"
 	"os"
-)
 
-var (
-	// Version variable will be replaced at link time after `make` has been run.
-	Version = "latest"
-
-	// GitHash variable will be replaced at link time after `make` has been run.
-	GitHash = "<NOT PROPERLY GENERATED>"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/service"
+	"go.opentelemetry.io/collector/service/parserprovider"
 )
 
 // Collector implements the OtelcolRunner interfaces running a single otelcol as a go routine within the

--- a/collector/main.go
+++ b/collector/main.go
@@ -23,7 +23,16 @@ import (
 	"syscall"
 
 	"github.com/open-telemetry/opentelemetry-lambda/collector/extension"
+	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdacollector"
 	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents"
+)
+
+var (
+	// Version variable will be replaced at link time after `make` has been run.
+	Version = "latest"
+
+	// GitHash variable will be replaced at link time after `make` has been run.
+	GitHash = "<NOT PROPERLY GENERATED>"
 )
 
 var (
@@ -35,7 +44,7 @@ func main() {
 	logln("Launching OpenTelemetry Lambda extension, version: ", Version)
 
 	factories, _ := lambdacomponents.Components()
-	collector := NewCollector(factories)
+	collector := lambdacollector.NewCollector(factories)
 	if err := collector.Start(); err != nil {
 		log.Fatalf("Failed to start the extension: %v", err)
 	}
@@ -61,7 +70,7 @@ func main() {
 	processEvents(ctx, collector)
 }
 
-func processEvents(ctx context.Context, collector *Collector) {
+func processEvents(ctx context.Context, collector *lambdacollector.Collector) {
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
It's not common to import from main packages in Go. Move the Collector to its own package to have a standalone entry point.