### PR TITLE
Revert "Move Collector to its own package"

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -12,17 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lambdacollector
+package main
 
 import (
 	"fmt"
-	"io"
-	"log"
-	"os"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/parserprovider"
+	"io"
+	"log"
+	"os"
+)
+
+var (
+	// Version variable will be replaced at link time after `make` has been run.
+	Version = "latest"
+
+	// GitHash variable will be replaced at link time after `make` has been run.
+	GitHash = "<NOT PROPERLY GENERATED>"
 )
 
 // Collector implements the OtelcolRunner interfaces running a single otelcol as a go routine within the

--- a/collector/main.go
+++ b/collector/main.go
@@ -23,16 +23,7 @@ import (
 	"syscall"
 
 	"github.com/open-telemetry/opentelemetry-lambda/collector/extension"
-	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdacollector"
 	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents"
-)
-
-var (
-	// Version variable will be replaced at link time after `make` has been run.
-	Version = "latest"
-
-	// GitHash variable will be replaced at link time after `make` has been run.
-	GitHash = "<NOT PROPERLY GENERATED>"
 )
 
 var (
@@ -44,7 +35,7 @@ func main() {
 	logln("Launching OpenTelemetry Lambda extension, version: ", Version)
 
 	factories, _ := lambdacomponents.Components()
-	collector := lambdacollector.NewCollector(factories)
+	collector := NewCollector(factories)
 	if err := collector.Start(); err != nil {
 		log.Fatalf("Failed to start the extension: %v", err)
 	}
@@ -70,7 +61,7 @@ func main() {
 	processEvents(ctx, collector)
 }
 
-func processEvents(ctx context.Context, collector *lambdacollector.Collector) {
+func processEvents(ctx context.Context, collector *Collector) {
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-lambda#73

Fixes #74

@rakyll Let's reintroduce the fix later, and I'll also add that ci step.