### PR TITLE
Update syntax to new lambda module version

### DIFF
--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -39,8 +39,8 @@ module "hello-lambda-function" {
 
 resource "aws_lambda_alias" "provisioned" {
   name             = "provisioned"
-  function_name    = module.hello-lambda-function.this_lambda_function_name
-  function_version = module.hello-lambda-function.this_lambda_function_version
+  function_name    = module.hello-lambda-function.lambda_function_name
+  function_version = module.hello-lambda-function.lambda_function_version
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "lambda_api" {

--- a/java/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -40,7 +40,7 @@ module "api-gateway" {
   source = "../../../../../utils/terraform/api-gateway-proxy"
 
   name                = var.name
-  function_name       = module.hello-lambda-function.this_lambda_function_name
-  function_invoke_arn = module.hello-lambda-function.this_lambda_function_invoke_arn
+  function_name       = module.hello-lambda-function.lambda_function_name
+  function_invoke_arn = module.hello-lambda-function.lambda_function_invoke_arn
   enable_xray_tracing = var.tracing_mode == "Active"
 }

--- a/java/sample-apps/okhttp/deploy/wrapper/main.tf
+++ b/java/sample-apps/okhttp/deploy/wrapper/main.tf
@@ -40,7 +40,7 @@ module "api-gateway" {
   source = "../../../../../utils/terraform/api-gateway-proxy"
 
   name                = var.name
-  function_name       = module.hello-lambda-function.this_lambda_function_name
-  function_invoke_arn = module.hello-lambda-function.this_lambda_function_invoke_arn
+  function_name       = module.hello-lambda-function.lambda_function_name
+  function_invoke_arn = module.hello-lambda-function.lambda_function_invoke_arn
   enable_xray_tracing = var.tracing_mode == "Active"
 }

--- a/nodejs/sample-apps/aws-sdk/deploy/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/main.tf
@@ -43,8 +43,8 @@ module "api-gateway" {
   source = "../../../../utils/terraform/api-gateway-proxy"
 
   name                = var.name
-  function_name       = module.hello-lambda-function.this_lambda_function_name
-  function_invoke_arn = module.hello-lambda-function.this_lambda_function_invoke_arn
+  function_name       = module.hello-lambda-function.lambda_function_name
+  function_invoke_arn = module.hello-lambda-function.lambda_function_invoke_arn
   enable_xray_tracing = var.tracing_mode == "Active"
 }
 

--- a/python/sample-apps/deploy/main.tf
+++ b/python/sample-apps/deploy/main.tf
@@ -40,7 +40,7 @@ module "api-gateway" {
   source = "../../../utils/terraform/api-gateway-proxy"
 
   name                = var.name
-  function_name       = module.hello-lambda-function.this_lambda_function_name
-  function_invoke_arn = module.hello-lambda-function.this_lambda_function_invoke_arn
+  function_name       = module.hello-lambda-function.lambda_function_name
+  function_invoke_arn = module.hello-lambda-function.lambda_function_invoke_arn
   enable_xray_tracing = var.tracing_mode == "Active"
 }


### PR DESCRIPTION
In another PR I'll check in terraform lock files to not allow provider versions to change transparently, but for not just updating syntax.