### PR TITLE
Check bundling attribute of agent dependency.

### DIFF
--- a/java/layer-javaagent/build.gradle.kts
+++ b/java/layer-javaagent/build.gradle.kts
@@ -2,7 +2,21 @@ plugins {
     `java-library`
 }
 
-val agentDependency = rootProject.findProperty("otel.lambda.javaagent.dependency")
+val agentDependency: String? = rootProject.findProperty("otel.lambda.javaagent.dependency") as String?
+
+val agent by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+
+val agentClasspath by configurations.creating {
+    extendsFrom(configurations["implementation"])
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes {
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling::class.java, Bundling.SHADOWED))
+    }
+}
 
 dependencies {
     if (agentDependency != null) {
@@ -17,8 +31,8 @@ tasks {
         archiveFileName.set("opentelemetry-javaagent-layer.zip")
         destinationDirectory.set(file("$buildDir/distributions"))
 
-        from(configurations["runtimeClasspath"]) {
-            rename("opentelemetry-javaagent-.*.jar", "opentelemetry-javaagent.jar")
+        from(agentClasspath) {
+            rename(".*.jar", "opentelemetry-javaagent.jar")
         }
 
         from("scripts")

--- a/java/layer-javaagent/build.gradle.kts
+++ b/java/layer-javaagent/build.gradle.kts
@@ -4,11 +4,6 @@ plugins {
 
 val agentDependency: String? = rootProject.findProperty("otel.lambda.javaagent.dependency") as String?
 
-val agent by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = false
-}
-
 val agentClasspath by configurations.creating {
     extendsFrom(configurations["implementation"])
     isCanBeConsumed = false


### PR DESCRIPTION
Agents are always shadowed, so we should enforce the bundling attribute. This didn't affect upstream agent dependency since it doesn't publish Gradle metadata yet, but AWS Distro does and was getting an empty file, and the transitive dependency on upstream was getting packaged in.