### PR TITLE
Add several processors since they are lightweight

### DIFF
--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -4,6 +4,14 @@ receivers:
       grpc:
       http:
 
+processors:
+  attributesprocessor:
+  filterprocessor:
+  memorylimiter:
+  probabilisticsamplerprocessor:
+  resourceprocessor:
+  spanprocessor:
+
 exporters:
   logging:
     loglevel: debug
@@ -13,6 +21,7 @@ service:
     traces:
       receivers: [otlp]
       exporters: [logging]
+      processors: [attributesprocessor, filterprocessor, memorylimiter, probabilisticsamplerprocessor, resourceprocessor, spanprocessor]
     metrics:
       receivers: [otlp]
       exporters: [logging]

--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -4,14 +4,6 @@ receivers:
       grpc:
       http:
 
-processors:
-  attributesprocessor:
-  filterprocessor:
-  memorylimiter:
-  probabilisticsamplerprocessor:
-  resourceprocessor:
-  spanprocessor:
-
 exporters:
   logging:
     loglevel: debug
@@ -21,7 +13,6 @@ service:
     traces:
       receivers: [otlp]
       exporters: [logging]
-      processors: [attributesprocessor, filterprocessor, memorylimiter, probabilisticsamplerprocessor, resourceprocessor, spanprocessor]
     metrics:
       receivers: [otlp]
       exporters: [logging]

--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -20,6 +20,12 @@ import (
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/processor/attributesprocessor"
+	"go.opentelemetry.io/collector/processor/filterprocessor"
+	"go.opentelemetry.io/collector/processor/memorylimiter"
+	"go.opentelemetry.io/collector/processor/probabilisticsamplerprocessor"
+	"go.opentelemetry.io/collector/processor/resourceprocessor"
+	"go.opentelemetry.io/collector/processor/spanprocessor"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
@@ -42,9 +48,22 @@ func Components() (component.Factories, error) {
 		errs = append(errs, err)
 	}
 
+	processors, err := component.MakeProcessorFactoryMap(
+		attributesprocessor.NewFactory(),
+		filterprocessor.NewFactory(),
+		memorylimiter.NewFactory(),
+		probabilisticsamplerprocessor.NewFactory(),
+		resourceprocessor.NewFactory(),
+		spanprocessor.NewFactory(),
+	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
 	factories := component.Factories{
 		Receivers: receivers,
 		Exporters: exporters,
+		Processors: processors,
 	}
 
 	return factories, consumererror.Combine(errs)


### PR DESCRIPTION
# Description

Fixes #102 

Initially, we hesitated with adding the `processors` because every Lambda function is subject to a [250 MB unzipped limit](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html) for the function and all the layers it includes.

However, when we added many of the processors (all except `batchprocessor` and `processorhelper`) available in https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor, we found that the size of the binary in the build only increased by ~700 KB:

```
 $ git/opentelemetry-lambda/collector du -k no-processors-build/extensions/collector
20064   no-processors-build/extensions/collector
 $ git/opentelemetry-lambda/collector du -k yes-processors-build/extensions/collector
20744   yes-processors-build/extensions/collector
```

This PR adds the processors so that they are available for lambda layers created using this repository.