### PR TITLE
Update Node AWS SDK instrumentation pkg to v0.23.0

### DIFF
--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -48,6 +48,6 @@
     "@opentelemetry/resource-detector-aws": "^0.23.0",
     "@opentelemetry/resources": "^0.23.0",
     "@opentelemetry/tracing": "^0.23.0",
-    "opentelemetry-instrumentation-aws-sdk": "^0.3.0"
+    "opentelemetry-instrumentation-aws-sdk": "^0.23.0"
   }
 }


### PR DESCRIPTION
# Description

Quick follow up to #112 . Initially I avoided changing `opentelemetry-instrumentation-aws-sdk` because it is [from another repo](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk), but because it is also at `v0.23.0` and seemingly regularly updated, I thought we might as well update it with the rest of the packages.

It released `v0.23.0` **just yesterday**.