### PR TITLE
Export to HTTP receiver at port 55681 for JS instead of default

### DIFF
--- a/nodejs/sample-apps/aws-sdk/deploy/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/main.tf
@@ -17,10 +17,11 @@ module "hello-lambda-function" {
   ])
 
   environment_variables = {
-    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler"
-    OTEL_TRACES_EXPORTER    = "logging"
-    OTEL_METRICS_EXPORTER   = "logging"
-    OTEL_LOG_LEVEL          = "DEBUG"
+    AWS_LAMBDA_EXEC_WRAPPER     = "/opt/otel-handler"
+    OTEL_TRACES_EXPORTER        = "logging"
+    OTEL_METRICS_EXPORTER       = "logging"
+    OTEL_LOG_LEVEL              = "DEBUG"
+    OTEL_EXPORTER_OTEL_ENDPOINT = "http://localhost:55681/v1/traces"
   }
 
   tracing_mode = var.tracing_mode


### PR DESCRIPTION
# Description

We found through a breaking build that the JS SDK was failing to send traces:

```
2021-07-07T04:45:05.033Z	94f1dfb8-8122-4f68-a103-ed1ea7f0d30e	DEBUG	Instrumentation suppressed, returning Noop Span
2021-07-07T04:45:05.034Z	94f1dfb8-8122-4f68-a103-ed1ea7f0d30e	DEBUG	@opentelemetry/instrumentation-http %s instrumentation outgoingRequest http
2021-07-07T04:45:05.034Z	94f1dfb8-8122-4f68-a103-ed1ea7f0d30e	DEBUG	@opentelemetry/instrumentation-http http.ClientRequest return request
2021-07-07T04:45:05.053Z	94f1dfb8-8122-4f68-a103-ed1ea7f0d30e	ERROR	{"stack":"Error: Parse Error: Expected HTTP/\n    at Socket.socketOnData (_http_client.js:515:22)\n    at Socket.emit (events.js:376:20)\n    at Socket.emit (domain.js:470:12)\n    at addChunk (internal/streams/readable.js:309:12)\n    at readableAddChunk (internal/streams/readable.js:284:9)\n    at Socket.Readable.push (internal/streams/readable.js:223:10)\n    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)\n    at TCP.callbackTrampoline (internal/async_hooks.js:134:14)","message":"Parse Error: Expected HTTP/","code":"HPE_INVALID_CONSTANT","reason":"Expected HTTP/","rawPacket":"\u0000\u0000\u0006\u0004\u0000\u0000\u0000\u0000\u0000\u0000\u0005\u0000\u0000@\u0000","name":"Error"}
END RequestId: 94f1dfb8-8122-4f68-a103-ed1ea7f0d30e
REPORT RequestId: 94f1dfb8-8122-4f68-a103-ed1ea7f0d30e	Duration: 1282.39 ms	Billed Duration: 1283 ms	Memory Size: 384 MB	Max Memory Used: 154 MB	Init Duration: 1519.08 ms	
```

Normally a collector will receive HTTP traces on port `55681`. But in this PR the default port for HTTP was changed from `55681` to `4317`. https://github.com/open-telemetry/opentelemetry-js/pull/2117/files#diff-c2d3229d30d1e2c1c6a140fad0ca1d9762f10481192b77143650057071eaead8L27

Here we set the environment variable for now to avoid confusion.