### PR TITLE
Log when a custom config is being used.

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -49,6 +49,7 @@ func getConfig() string {
 	if !ex {
 		return "/opt/collector-config/config.yaml"
 	}
+	log.Printf("Using config file at path %v", val)
 	return val
 }
 


### PR DESCRIPTION
When users are using a custom config but it isn't working, there is always the possibility that the custom config isn't being picked up. With this log, we can confirm that and then debug elsewhere.