### PR TITLE
Allow setting the args of the collector via environment variable.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -73,3 +73,16 @@ You can configure environment variables via CloudFormation template as well:
         Variables:
           OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yaml
 ```
+
+You can configure arguments passed to the collector command line with the
+`OPENTELEMETRY_COLLECTOR_ARGS` environment variable.
+
+```yaml
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      ...
+      Environment:
+        Variables:
+          OPENTELEMETRY_COLLECTOR_ARGS: --log-level=debug
+```

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 )
 
 var (
@@ -81,7 +82,9 @@ func (c *Collector) Start() error {
 	if err != nil {
 		return err
 	}
-	c.svc.Command().SetArgs([]string{"--metrics-level=NONE"})
+	if args, ok := os.LookupEnv("OPENTELEMETRY_COLLECTOR_ARGS"); ok {
+		c.svc.Command().SetArgs(strings.Split(args, " "))
+	}
 
 	c.appDone = make(chan struct{})
 	go func() {


### PR DESCRIPTION
For example `OPENTELEMETRY_COLLECTOR_ARGS=--loglevel=debug`.

Also removes the current `metrics-level` default setting which seems arbitrary, the collector extension should just run with collector defaults.

Fixes #63