### PR TITLE
chore: enable metrics on java

### DIFF
--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -21,9 +21,11 @@ module "hello-lambda-function" {
   environment_variables = (var.collector_config_layer_arn == null ?
     {
       AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
+      OTEL_METRICS_EXPORTER   = "otlp",
     } :
     {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
+      OTEL_METRICS_EXPORTER               = "otlp",
       OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/opt/config.yaml"
   })
 


### PR DESCRIPTION
Since the Java agent has metric exporting disabled by default starting in 1.6.0, we need to manually enable them for some integ tests for the awssdk app.