### PR TITLE
Remove explicit deps on OTel Python Core pkgs

### DIFF
--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,6 +1,3 @@
-opentelemetry-api==1.5.0
-opentelemetry-sdk==1.5.0
 opentelemetry-exporter-otlp==1.5.0
 opentelemetry-distro==0.24b0
-opentelemetry-instrumentation==0.24b0
 opentelemetry-sdk-extension-aws==1.0.1

--- a/python/src/otel/tests/test-requirements.txt
+++ b/python/src/otel/tests/test-requirements.txt
@@ -1,6 +1,3 @@
-opentelemetry-api==1.5.0
-opentelemetry-sdk==1.5.0
 opentelemetry-distro==0.24b0
-opentelemetry-instrumentation==0.24b0
 opentelemetry-sdk-extension-aws==1.0.1
 pytest


### PR DESCRIPTION
# Description

Follow up to the conversation on https://github.com/open-telemetry/opentelemetry-lambda/pull/145#discussion_r714246315 with @willarmiros, where we mentioned that because we already install `opentelemetry-sdk-extension==1.0.1`, we get the following packages installed as dependencies.
* `opentelemetry-api`
* `opentelemetry-sdk`
* `opentelemetry-instrumentation`

This is the preferable pattern because we can get a version conflict otherwise.