### PR TITLE
update readme log level flag

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -84,5 +84,5 @@ You can configure arguments passed to the collector command line with the
       ...
       Environment:
         Variables:
-          OPENTELEMETRY_COLLECTOR_ARGS: --log-level=debug
+          OPENTELEMETRY_COLLECTOR_ARGS: --set=service.telemetry.logs.level=debug
 ```


### PR DESCRIPTION
`--log-level` is being deprecated as of v0.36.0 of the collector in favour of either the following flag `--set=service.telemetry.logs.level=debug` or configuring the log level via yaml. This PR updates the readme accordingly.