### PR TITLE
Init TracerProvider ourselves to set immutable Resource attribute

### DIFF
--- a/python/src/otel/otel_sdk/otel_wrapper.py
+++ b/python/src/otel/otel_sdk/otel_wrapper.py
@@ -5,12 +5,33 @@ from importlib import import_module
 from pkg_resources import iter_entry_points
 
 from opentelemetry.instrumentation.dependencies import get_dist_dependency_conflicts
+from opentelemetry import trace
+
 from opentelemetry.instrumentation.aws_lambda import AwsLambdaInstrumentor
 from opentelemetry.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
 from opentelemetry.instrumentation.distro import BaseDistro, DefaultDistro
 
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource, get_aggregated_resources
+
+# NOTE: These are private methods, and _very_ subject to change. We use them
+# because we have to, explained in `context_to_otel_sdk_tracer_provider` below.
+from opentelemetry.sdk._configuration import (
+    _get_exporter_names,
+    _get_id_generator,
+    _import_exporters,
+    _import_id_generator,
+)
+
+from opentelemetry.semconv.resource import ResourceAttributes
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+from opentelemetry.sdk.extension.aws.resource import AwsLambdaResourceDetector
+from opentelemetry.sdk.resources import Resource
 
 # TODO: waiting OTel Python supports env variable config for resource detector
 # from opentelemetry.resource import AwsLambdaResourceDetector
@@ -35,6 +56,7 @@ def _load_distros() -> BaseDistro:
         except Exception as exc:  # pylint: disable=broad-except
             logger.debug("Distribution %s configuration failed", entry_point.name)
     return DefaultDistro()
+
 
 def _load_instrumentors(distro):
     package_to_exclude = os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, [])
@@ -66,22 +88,6 @@ def _load_instrumentors(distro):
         except Exception as exc:  # pylint: disable=broad-except
             logger.debug("Instrumenting of %s failed", entry_point.name)
 
-def _load_configurators():
-    configured = None
-    for entry_point in iter_entry_points("opentelemetry_configurator"):
-        if configured is not None:
-            logger.warning(
-                "Configuration of %s not loaded, %s already loaded",
-                entry_point.name,
-                configured,
-            )
-            continue
-        try:
-            entry_point.load()().configure()  # type: ignore
-            configured = entry_point.name
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug("Configuration of %s failed", entry_point.name)
-
 
 def modify_module_name(module_name):
     """Returns a valid modified module to get imported"""
@@ -92,10 +98,54 @@ class HandlerError(Exception):
 
 distro = _load_distros()
 distro.configure()
-_load_configurators()
+
+
+def context_to_otel_sdk_tracer_provider(lambda_context):
+    """Sets and gets the global TracerProvider using the OpenTelemetry Python
+    SDK Implemention using the Lambda Context.
+
+    NOTE: We would have liked to let the `opentelemetry_configurator` default
+    class `from opentelemetry.sdk._configuration` do this for us but we cannot.
+
+    We _must_ wait to set the `TracerProvider` until the `lambda_context` is
+    available because we want to add an attribute to the OpenTelemetry Python
+    SDK `Resource` on the `TracerProvider. There is no other opportunity to set
+    this because the `TracerProvider` and `Resource` are immutable.
+
+    Args:
+        lambda_context: defined by the AWS Lambda service, contains metadata
+            like the `invoked_function_arn`.
+    Returns:
+        The `TracerProvider` it just created and set using the `lambda_context`
+    """
+    id_generator_name = _get_id_generator()
+    id_generator = _import_id_generator(id_generator_name)
+
+    tracer_provider = TracerProvider(
+        id_generator=id_generator(),
+        resource=Resource(
+            {ResourceAttributes.FAAS_ID: lambda_context.invoked_function_arn}
+        ).merge(get_aggregated_resources([AwsLambdaResourceDetector()])),
+    )
+
+    exporter_names = _get_exporter_names()
+    trace_exporters = _import_exporters(exporter_names)
+
+    for _, exporter_class in trace_exporters.items():
+        exporter_args = {}
+        tracer_provider.add_span_processor(
+            BatchSpanProcessor(exporter_class(**exporter_args))
+        )
+
+    trace.set_tracer_provider(tracer_provider)
+
+    return trace.get_tracer_provider()
+
+
+AwsLambdaInstrumentor().instrument(
+    context_to_trace_provider=context_to_otel_sdk_tracer_provider,
+)
 _load_instrumentors(distro)
-# TODO: move to python-contrib
-AwsLambdaInstrumentor().instrument(skip_dep_check=True)
 
 path = os.environ.get("ORIG_HANDLER", None)
 if path is None:


### PR DESCRIPTION
# Description

We are getting ready to upstream this `AwsLambdaInstrumentor` to [the OpenTelemetry Python Contrib repo](https://github.com/open-telemetry/opentelemetry-python-contrib/). In doing so, there is a caveat because one of the `Resource` attributes cannot be set until the Lambda function is actually invoked and the `lambda_context` is available.

This PR tries to solve that. Instead of letting the `opentelemetry_configurator` entry point configure the `TracerProvider`. We take the relevant methods and try to initialize the `TraceProvider` ourselves. We must, because we can't initialize again after it's done. It is immutable (and so is its `Resource`).

There are some other miscellaneous formatting changes and doc changes. If it's too busy I can remove these and focus on this solution first!