### PR TITLE
Add back dependency on instrumentation pkg because of sdk pkg updates

### DIFF
--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,3 +1,4 @@
 opentelemetry-exporter-otlp==1.5.0
 opentelemetry-distro==0.24b0
 opentelemetry-sdk-extension-aws==1.0.1
+opentelemetry-instrumentation==0.24b0


### PR DESCRIPTION
In #148 we had removed our dependency on `opentelemetry-instrumentation` because the `opentelemetry-sdk` package depended on it.

Recently, upstream moved **removed** `opentelemetry-sdk`'s dependency on it: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/738

This PR is just anticipating that change for the next Lambda release so that we don't have any surprises about missing imports.

cc @willarmiros 