### PR TITLE
Lambda Layer Update - OTel Java 1.7

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,17 +9,17 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.6.0-alpha",
-    "io.grpc:grpc-bom:1.40.1",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.7.0-alpha",
+    "io.grpc:grpc-bom:1.41.0",
     "org.apache.logging.log4j:log4j-bom:2.14.1",
-    "software.amazon.awssdk:bom:2.17.29"
+    "software.amazon.awssdk:bom:2.17.63"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.10.0",
-    "com.squareup.okhttp3:okhttp:4.9.1",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.6.0"
+    "com.squareup.okhttp3:okhttp:4.9.2",
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.7.0"
 )
 
 javaPlatform {

--- a/java/layer-javaagent/build.gradle.kts
+++ b/java/layer-javaagent/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     if (agentDependency != null) {
         implementation(agentDependency)
     } else {
-        implementation("io.opentelemetry.javaagent", "opentelemetry-javaagent", classifier = "all")
+        implementation("io.opentelemetry.javaagent", "opentelemetry-javaagent")
     }
 }
 


### PR DESCRIPTION
# Description

Updates the Java Lambda Layer to use the latest versions of OTel JS
* 1.7.0-alpha `io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha`
* 1.7.0 `io.opentelemetry.javaagent:opentelemetry-javaagent`

Guided some of the updates to the dependencies based on https://github.com/aws-observability/aws-otel-java-instrumentation/pull/103