### PR TITLE
Make sure env var Python Resource Attr pairs are valid

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -120,7 +120,14 @@ fi
 #       )
 #   )
 
-export OTEL_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,$OTEL_RESOURCE_ATTRIBUTES";
+export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION";
+
+if [ -z ${OTEL_RESOURCE_ATTRIBUTES} ]; then
+    export OTEL_RESOURCE_ATTRIBUTES=$LAMBDA_RESOURCE_ATTRIBUTES;
+else
+    export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
+fi
+
 
 # - Uses the default `OTEL_PROPAGATORS` which is set to `tracecontext,baggage`
 


### PR DESCRIPTION
# Description

Follow up to #164, where we wrongly assumed an empty string `""` would be filtered by the upstream OTel Python SDK.

As explained in https://github.com/open-telemetry/opentelemetry-python/pull/2256, this is not sanitized properly, so we need to ensure that all values in `OTEL_RESOURCE_ATTRIBUTES` are valid.