### PR TITLE
Support building Collector for arm64 architecture

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [ amd64, arm64 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -28,5 +31,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: make package
+      - name: Build Collector Executable for ${{ matrix.architecture }} architecture
+        run: GOARCH=${{ matrix.architecture }} make package
         working-directory: collector

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -5,6 +5,7 @@ LAYER_NAME:=otel-collector
 
 VERSION=$(shell cat VERSION)
 GIT_SHA=$(shell git rev-parse HEAD)
+GOARCH=${GOARCH-amd64}
 GOBUILD=GO111MODULE=on CGO_ENABLED=0 installsuffix=cgo go build -trimpath
 BUILD_INFO_IMPORT_PATH=main
 
@@ -17,7 +18,7 @@ clean:
 build: clean
 	@echo Building otel collector extension
 	mkdir -p $(BUILD_SPACE)/extensions
-	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_SPACE)/extensions .
+	GOOS=linux $(GOBUILD) $(LDFLAGS) -o $(BUILD_SPACE)/extensions .
 
 package: build
 	@echo Package zip file for collector extension layer

--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,4 +1,4 @@
-opentelemetry-exporter-otlp==1.7.1
+opentelemetry-exporter-otlp-proto-http==1.7.1
 opentelemetry-distro==0.26b1
 opentelemetry-propagator-aws-xray==1.0.1
 opentelemetry-instrumentation==0.26b1


### PR DESCRIPTION
## Description

Exposes the `GOARCH` environment variable for invocations of `make package` so that the collector program that is built can be configured for other architectures like `arm64`.