### PR TITLE
Use Go 1.17 because Collector cannot be built without it

### DIFF
--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v2
-      - name: Setup Python
+      - name: Setup Python for OTel Python SDK
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
@@ -31,7 +31,10 @@ jobs:
         run: |
           pip install tox
           tox
-      - name: Build layer
+      - name: Set up Go for ADOT Collector
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17'
+      - name: Build Python Layer which includes ADOT Collector
         working-directory: python/src
         run: ./run.sh -b
-

--- a/python/src/otel/Makefile
+++ b/python/src/otel/Makefile
@@ -1,13 +1,5 @@
-export AOC=$(shell pwd)/otel_collector
+export AOC_BUILD_DIR=$(shell pwd)/collector_build
 export SDK=$(shell pwd)/otel_sdk
-
-VERSION=$(shell cat $(AOC)/VERSION)
-GIT_SHA=$(shell git rev-parse HEAD)
-GOBUILD=GO111MODULE=on CGO_ENABLED=0 installsuffix=cgo go build -trimpath
-BUILD_INFO_IMPORT_PATH=main
-
-LDFLAGS=-ldflags "-s -w -X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA) -X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION) \
--X github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter.collectorDistribution=aws-otel-collector-lambda"
 
 build-OTelLayer:
 	mkdir -p $(ARTIFACTS_DIR)/python
@@ -20,9 +12,4 @@ build-OTelLayer:
 	rm -rf $(ARTIFACTS_DIR)/python/boto*
 	rm -rf $(ARTIFACTS_DIR)/python/urllib3*
 
-	rpm --rebuilddb
-	yum install -y go
-	mkdir -p $(ARTIFACTS_DIR)/extensions
-	cd $(AOC) && $(GOBUILD) $(LDFLAGS) -o $(ARTIFACTS_DIR)/extensions/collector .
-	mkdir -p $(ARTIFACTS_DIR)/collector-config
-	cp $(AOC)/config* $(ARTIFACTS_DIR)/collector-config/
+	cp -r $(AOC_BUILD_DIR)/* $(ARTIFACTS_DIR)/

--- a/utils/sam/run.sh
+++ b/utils/sam/run.sh
@@ -85,10 +85,16 @@ main() {
 
 	if [[ $build == true ]]; then
 		echo "sam building..."
-		rm -rf .aws-sam
-		rm -rf otel/otel_collector
-		mkdir -p otel/otel_collector
-		cp -r "$collectorPath"/* otel/otel_collector
+
+		echo "run.sh: building the collector..."
+		pushd $collectorPath || exit
+		make package
+		rm build/collector-extension.zip
+		popd || exit
+		rm -rf otel/collector_build/
+		cp -r $collectorPath/build/ otel/collector_build/
+
+		echo "run.sh: Starting sam build."
 		sam build -u -t $template
 	fi
 


### PR DESCRIPTION
## Description

Build collector before we use SAM Docker Container.
* The recent v0.39.0 collector introduced a change that required go 1.17
* We can't download go 1.17 in the Docker Container used by SAM
* We build the collector outside the Docker Container and just copy over later