### PR TITLE
Use Makefile operator to get GOARCH default

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -34,3 +34,16 @@ jobs:
       - name: Build Collector Executable for ${{ matrix.architecture }} architecture
         run: GOARCH=${{ matrix.architecture }} make package
         working-directory: collector
+      - name: Confirm architecture of built collector
+        working-directory: collector/build/extensions
+        run: |
+          if [ "${{ matrix.architecture }}" = "amd64" ]
+          then
+            SEARCH_STRING=x86
+          elif [ "${{ matrix.architecture }}" = "arm64" ]
+          then
+            SEARCH_STRING=ARM
+          else
+            exit 2
+          fi
+          grep "$SEARCH_STRING" <<< "$(file collector)"

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -5,7 +5,7 @@ LAYER_NAME:=otel-collector
 
 VERSION=$(shell cat VERSION)
 GIT_SHA=$(shell git rev-parse HEAD)
-GOARCH=${GOARCH-amd64}
+GOARCH ?= amd64
 GOBUILD=GO111MODULE=on CGO_ENABLED=0 installsuffix=cgo go build -trimpath
 BUILD_INFO_IMPORT_PATH=main
 


### PR DESCRIPTION
## Description

I completely forgot to change this line in #181 which is crucial so that the Makefile will read the `GOARCH` environment variable if one is specified.

This PR fixes that and also adds a PR time workflow to test that the collector can be built correctly for multiple architectures.