### PR TITLE
Use HTTP OTLP Exporter because it is architecture agnostic

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -84,7 +84,14 @@ export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 
 # Configure OpenTelemetry Python with environment variables
 
-# - Uses the default `OTEL_TRACES_EXPORTER` which is set to `otlp_proto_grpc`
+# - We leave `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to its default. This is
+#   `http://localhost:4318/v1/traces` because we are using the HTTP exporter
+
+# - Set the trace exporter
+
+if [ -z ${OTEL_TRACES_EXPORTER} ]; then
+    export OTEL_TRACES_EXPORTER=otlp_proto_http;
+fi
 
 # - Set the service name
 


### PR DESCRIPTION
## Description

Follow up to #181 which does not download the `opentelmetry-exporter-otlp-grpc` package because it downloaded C architecture specific code. We need to **change the default exporter** to be for HTTP as well. This is so we can distribute both `arm64` and `amd64` Lambda Layers without worrying about architecture specific code.