### PR TITLE
Use CI for logic branching instead of bash

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -34,16 +34,13 @@ jobs:
       - name: Build Collector Executable for ${{ matrix.architecture }} architecture
         run: GOARCH=${{ matrix.architecture }} make package
         working-directory: collector
+      - name: Get Lambda Layer amd64 architecture value
+        if: ${{ matrix.architecture == 'amd64' }}
+        run: echo LAMBDA_LAYER_ARCHITECTURE=x86 | tee --append $GITHUB_ENV
+      - name: Get Lambda Layer arm64 architecture value
+        if: ${{ matrix.architecture == 'arm64' }}
+        run: echo LAMBDA_LAYER_ARCHITECTURE=ARM | tee --append $GITHUB_ENV
       - name: Confirm architecture of built collector
         working-directory: collector/build/extensions
         run: |
-          if [ "${{ matrix.architecture }}" = "amd64" ]
-          then
-            SEARCH_STRING=x86
-          elif [ "${{ matrix.architecture }}" = "arm64" ]
-          then
-            SEARCH_STRING=ARM
-          else
-            exit 2
-          fi
-          grep "$SEARCH_STRING" <<< "$(file collector)"
+          grep ${{ env.LAMBDA_LAYER_ARCHITECTURE }} <<< "$(file collector)"


### PR DESCRIPTION
## Description

Follow up to #184 where we confirmed that the built executable was for the intended architecture by reading the `file` info.

In this PR, we just use GH action steps to do logic branching to make debugging in the future easier. This is because the step will only run if the condition is met instead of being hidden in the bash code of the step.