### PR TITLE
Follow up consistent file naming with fixes

### DIFF
--- a/go/integration-tests/aws-sdk/wrapper/main.tf
+++ b/go/integration-tests/aws-sdk/wrapper/main.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 }
 
 module "hello-lambda-function" {
-  source              = "../../../sample-apps/deploy"
+  source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   tracing_mode        = var.tracing_mode

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 }
 
 module "hello-lambda-function" {
-  source              = "../../../sample-apps/aws-sdk/deploy"
+  source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 }
 
 module "hello-lambda-function" {
-  source              = "../../../sample-apps/deploy"
+  source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn


### PR DESCRIPTION
* In #189 we modified several terraform file paths to be consistent across all languages, but these last ones got missed
* We fix them after having tested on a forked repo that confirms these are the ones we need

Using [my fork of aws-otel-lambda](https://github.com/NathanielRN/aws-otel-lambda/actions) to confirm if the `main-build.yml` passes because it is the first workflow to use the terraform integration tests.

Here is a workflow [that passed on the main build](https://github.com/NathanielRN/aws-otel-lambda/runs/4373492744?check_suite_focus=true) to provide proof that this works! (Python failed because we need #185 to be merged 🙂)