### PR TITLE
Support architecture input variable in integration tests

### DIFF
--- a/dotnet/integration-tests/aws-sdk/wrapper/main.tf
+++ b/dotnet/integration-tests/aws-sdk/wrapper/main.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
+  architecture        = var.architecture
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   tracing_mode        = var.tracing_mode
 }

--- a/dotnet/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/dotnet/integration-tests/aws-sdk/wrapper/variables.tf
@@ -21,3 +21,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}

--- a/go/integration-tests/aws-sdk/wrapper/main.tf
+++ b/go/integration-tests/aws-sdk/wrapper/main.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
+  architecture        = var.architecture
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   tracing_mode        = var.tracing_mode
 }

--- a/go/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/go/integration-tests/aws-sdk/wrapper/variables.tf
@@ -21,3 +21,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -18,6 +18,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source                     = "../../../sample-apps/aws-sdk/deploy/agent"
   name                       = var.function_name
+  architecture               = var.architecture
   collector_layer_arn        = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn              = aws_lambda_layer_version.sdk_layer.arn
   collector_config_layer_arn = var.collector_config_layer_arn

--- a/java/integration-tests/aws-sdk/agent/variables.tf
+++ b/java/integration-tests/aws-sdk/agent/variables.tf
@@ -32,3 +32,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}

--- a/java/integration-tests/aws-sdk/wrapper/main.tf
+++ b/java/integration-tests/aws-sdk/wrapper/main.tf
@@ -18,6 +18,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
+  architecture        = var.architecture
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
   tracing_mode        = var.tracing_mode

--- a/java/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/java/integration-tests/aws-sdk/wrapper/variables.tf
@@ -27,3 +27,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}

--- a/java/integration-tests/okhttp/wrapper/main.tf
+++ b/java/integration-tests/okhttp/wrapper/main.tf
@@ -18,6 +18,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source              = "../../../sample-apps/okhttp/deploy/wrapper"
   name                = var.function_name
+  architecture        = var.architecture
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
   tracing_mode        = var.tracing_mode

--- a/java/integration-tests/okhttp/wrapper/variables.tf
+++ b/java/integration-tests/okhttp/wrapper/variables.tf
@@ -27,3 +27,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -18,6 +18,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
+  architecture        = var.architecture
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
   tracing_mode        = var.tracing_mode

--- a/nodejs/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/variables.tf
@@ -27,3 +27,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -18,6 +18,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
 module "hello-lambda-function" {
   source              = "../../../sample-apps/aws-sdk/deploy/wrapper"
   name                = var.function_name
+  architecture        = var.architecture
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
   tracing_mode        = var.tracing_mode

--- a/python/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/python/integration-tests/aws-sdk/wrapper/variables.tf
@@ -27,3 +27,9 @@ variable "enable_collector_layer" {
   description = "Enables building and usage of a layer for the collector. If false, it means either the SDK layer includes the collector or it is not used."
   default     = true
 }
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}


### PR DESCRIPTION
## Description

Because Lambda supports multiple architectures (x86_64 and ARM64 as of now), we want to update our terraform files to accept the architecture as an input.

See the [terraform documentation for the AWS Lambda function](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws/latest#input_architectures).