### PR TITLE
Support arm64 for .NET and Go Sample Lambda Funcs

### DIFF
--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
@@ -1,6 +1,24 @@
 #!/bin/sh
 
+GOARCH=${GOARCH-amd64}
+
+# Chosen from Microsoft's documentation for Runtime Identifier (RIDs)
+# See more: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#linux-rids
+if [ $GOARCH = "amd64" ]; then
+    DOTNET_LINUX_ARCH=x64
+elif [ $GOARCH = "arm64" ]; then
+    DOTNET_LINUX_ARCH=arm64
+else
+    echo "Invalid GOARCH value `$GOARCH` received."
+    exit 2
+fi
+
 mkdir -p build/dotnet
-dotnet publish --output "./build/dotnet" --configuration "Release" --framework "netcoreapp3.1" /p:GenerateRuntimeConfigurationFiles=true --runtime linux-x64 --self-contained false 
+dotnet publish \
+    --output "./build/dotnet" \
+    --configuration "Release" \
+    --framework "netcoreapp3.1" /p:GenerateRuntimeConfigurationFiles=true \
+    --runtime linux-$DOTNET_LINUX_ARCH \
+    --self-contained false
 cd build/dotnet || exit
 zip -r ../function.zip *

--- a/go/sample-apps/function/build.sh
+++ b/go/sample-apps/function/build.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
+GOARCH=${GOARCH-amd64}
+
 mkdir -p build
-GOOS=linux GOARCH=amd64 go build -o ./build/bootstrap .
+GOOS=linux go build -o ./build/bootstrap .
 cd build || exit
 zip bootstrap.zip bootstrap


### PR DESCRIPTION
## Description

In #181 and #184 we made it possible for the Collector to be built with a different architecture, specifically from the `GOARCH` environment variable.

In this PR, we update the .NET and Go apps to also read from the `GOARCH` variable to decide what architecture to build its sample Lambda functions for.