### PR TITLE
Fix scoping bug for errors on collector service Run

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -81,11 +81,7 @@ func (c *Collector) Start(ctx context.Context) error {
 	go func(runErr chan error) {
 		defer close(c.appDone)
 		err := c.svc.Run(context.Background())
-		if err != nil {
-			runErr <- err
-		} else {
-			runErr <- nil
-		}
+		runErr <- err
 	}(runErr)
 
 	rErr := <-runErr


### PR DESCRIPTION
I had a tab error in my config yaml and the extension layer collector was hanging with no error output which led me to this bug.

The current logic will never receive the error returned from `appErr := c.svc.Run(ctx)`  because error will be out of scope and the collector will hang.  This creates a channel and assures we check the error. This allows us to get the config error.  