### PR TITLE
 Fix scoping bug for errors on collector service Run

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -78,11 +78,11 @@ func (c *Collector) Start(ctx context.Context) error {
 
 	c.appDone = make(chan struct{})
 	runErr := make(chan error, 1)
-	go func(runErr chan error) {
+	go func() {
 		defer close(c.appDone)
-		err := c.svc.Run(context.Background())
+		err := c.svc.Run(ctx)
 		runErr <- err
-	}(runErr)
+	}()
 
 	rErr := <-runErr
 	if rErr != nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -77,13 +77,18 @@ func (c *Collector) Start(ctx context.Context) error {
 	}
 
 	c.appDone = make(chan struct{})
-	go func() {
+	runErr := make(chan error, 1)
+	go func(runErr chan error) {
 		defer close(c.appDone)
-		appErr := c.svc.Run(ctx)
-		if appErr != nil {
-			err = appErr
-		}
-	}()
+		err := c.svc.Run(context.Background())
+		runErr <- err
+	}(runErr)
+
+	rErr := <-runErr
+	if rErr != nil {
+		return rErr
+	}
+	close(runErr)
 
 	for state := range c.svc.GetStateChannel() {
 		switch state {


### PR DESCRIPTION
I had a tab error in my config yaml and the extension layer collector was hanging with no error output which led me to this bug.

The current logic will never receive the error returned from `appErr := c.svc.Run(ctx)` because error will be out of scope and the collector will hang. This creates a channel and assures we check the error. This allows us to get the config error.