### PR TITLE
Install AWS Lambda Instrumentation dependencies

### DIFF
--- a/python/src/otel/otel_sdk/requirements-nodeps.txt
+++ b/python/src/otel/otel_sdk/requirements-nodeps.txt
@@ -2,7 +2,6 @@ opentelemetry-instrumentation-aiohttp-client==0.26b1
 opentelemetry-util-http==0.26b1
 asgiref~=3.0
 opentelemetry-instrumentation-asgi==0.26b1
-opentelemetry-instrumentation-aws-lambda==0.26b1
 opentelemetry-instrumentation-asyncpg==0.26b1
 opentelemetry-instrumentation-boto==0.26b1
 opentelemetry-instrumentation-botocore==0.26b1

--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,4 +1,3 @@
 opentelemetry-exporter-otlp-proto-http==1.7.1
 opentelemetry-distro==0.26b1
-opentelemetry-propagator-aws-xray==1.0.1
-opentelemetry-instrumentation==0.26b1
+opentelemetry-instrumentation-aws-lambda==0.26b1


### PR DESCRIPTION
# Description

* The AWS Lambda Instrumentation already brings in the AWS X-Ray Propagator as a dependency
* The AWS X-Ray Propagator is used regardless of vendor to extract a parent context in Lambda
* Install Lambda Instr and its dependencies to avoid people accidentally removing the propagator

You can confirm that `opentelemetry-instrumentation-aws-lambda` installs the `opentelemetry-instrumentation` and `opentelemetry-propagator-aws-xray` package from OTel Python Contrib Upstream:

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/07f81461df3e87da0495475d79eed415f3698634/instrumentation/opentelemetry-instrumentation-aws-lambda/setup.cfg#L40-L42