### PR TITLE
Bring in new OTel Java 1.10.1 Wrapper Dependencies

### DIFF
--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     runtimeOnly(project(":awssdk-autoconfigure"))
 
+    runtimeOnly("com.fasterxml.jackson.core:jackson-core")
+
     runtimeOnly("io.grpc:grpc-netty-shaded")
     runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-1.0")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-logging")


### PR DESCRIPTION
## Description

The ADOT Java Wrapper Lambda Layer was [failing in the most recent Main Build Tests](https://github.com/aws-observability/aws-otel-lambda/runs/5011153111?check_suite_focus=true), but the error message was not very helpful:

```
19:31:49.802 [main] INFO  com.amazon.aoc.helpers.RetryHelper - retry attempt left : 1 
19:31:52.560 [main] INFO  com.amazon.aoc.callers.HttpCaller - response from sample app {"message": "Internal server error"}
```

So I went into the actual Lambda and ran the code, where I found this error:

```
{
  "errorMessage": "Error loading class io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestApiGatewayWrapper: com/fasterxml/jackson/databind/ObjectMapper",
  "errorType": "java.lang.NoClassDefFoundError"
}
```

This made me look up how the upstream OTel Lambda Instrumentation had changed the `io.opentelemetry.instrumentation.awslambda.v1_0` package recently, and I found this crucial PR: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4254 by @kubawach.

In that PR he added references to the `com.fasterxml.jackson.core` project and its packages, but our Lambda environment does not have this package so it was failing.

In this PR I added those 2 packages as `runtimeOnly` dependencies.

When I add these changes and run the tests, the Lambda function completes successfully:

```
{
  "body": "Hello lambda - found 32 buckets."
}
```

## Follow up

Couldn't the `com.fasterxml.jackson.core` packages be a dependency of the `io.opentelemetry.instrumentation.awslambda.v1_0` package instead?

Confirmed that it should be included upstream, made a PR for it: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5284