### PR TITLE
Use 'databind' dependency not 'core' in Lambda env

### DIFF
--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -2,13 +2,12 @@ plugins {
     `java-library`
 }
 
-
 dependencies {
-    runtimeOnly(project(":awssdk-autoconfigure"))
-
     // TODO: Remove this when fix released upstream
-    // See here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5284
-    runtimeOnly("com.fasterxml.jackson.core:jackson-core")
+    // See here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5285
+    runtimeOnly("com.fasterxml.jackson.core:jackson-databind")
+
+    runtimeOnly(project(":awssdk-autoconfigure"))
 
     runtimeOnly("io.grpc:grpc-netty-shaded")
     runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-1.0")


### PR DESCRIPTION
## Description

Follow up to #211, we _did_ need to bring in a new dependency, but we brought in the wrong one. We need `jackson-databind` not `jackson-core`.

~We also use `implementation` instead of `runtimeOnly` because we want it to be used both when compiling and when published in the POM for downstream, but we don't need to leak it to other modules. We just want it in this one so we have it for BOTH compile time & run time.~

We can use `runtimeOnly` because we don't compile any code.