### PR TITLE
feat: add extension point for customising lambda instrumentation

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -19,6 +19,7 @@ import {
   DiagLogLevel,
 } from "@opentelemetry/api";
 import { getEnv } from '@opentelemetry/core';
+import { AwsLambdaInstrumentationConfig} from '@opentelemetry/instrumentation-aws-lambda';
 
 // Use require statements for instrumentation to avoid having to have transitive dependencies on all the typescript
 // definitions.
@@ -45,6 +46,7 @@ declare global {
   function configureSdkRegistration(
     defaultSdkRegistration: SDKRegistrationConfig
   ): SDKRegistrationConfig;
+  function configureLambdaInstrumentation(config: AwsLambdaInstrumentationConfig): AwsLambdaInstrumentationConfig
 }
 
 console.log('Registering OpenTelemetry');
@@ -53,7 +55,7 @@ const instrumentations = [
   new AwsInstrumentation({
     suppressInternalInstrumentation: true,
   }),
-  new AwsLambdaInstrumentation(),
+  new AwsLambdaInstrumentation(typeof configureLambdaInstrumentation === 'function' ? configureLambdaInstrumentation({}) : {}),
   new DnsInstrumentation(),
   new ExpressInstrumentation(),
   new GraphQLInstrumentation(),

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -19,7 +19,7 @@ import {
   DiagLogLevel,
 } from "@opentelemetry/api";
 import { getEnv } from '@opentelemetry/core';
-import { AwsLambdaInstrumentationConfig} from '@opentelemetry/instrumentation-aws-lambda';
+import { AwsLambdaInstrumentationConfig } from '@opentelemetry/instrumentation-aws-lambda';
 
 // Use require statements for instrumentation to avoid having to have transitive dependencies on all the typescript
 // definitions.


### PR DESCRIPTION
## Which problem is this PR solving?
There is no easy way to customise the ```AwsLambdaInstrumentation```, it's currently created with default arguments when there are in reality a range of things that can be customised on it, such as ```disableAwsContextPropagation``` and the custom event extractor.

This PR adds a global ```configureLambdaInstrumentation``` function which allows downstream code to customise the config before the instrumentation is created

### Short description of the changes
- Add ```configureLambdaInstrumentation``` alongside the other provided ```configure...``` extension points