### PR TITLE
Lambda Layer Update - OTel Java 1.11.1

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,17 +9,17 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.10.1-alpha",
-    "io.grpc:grpc-bom:1.42.1",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.11.0-alpha",
+    "io.grpc:grpc-bom:1.44.0",
     "org.apache.logging.log4j:log4j-bom:2.17.1",
-    "software.amazon.awssdk:bom:2.17.112"
+    "software.amazon.awssdk:bom:2.17.132"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
-    "com.squareup.okhttp3:okhttp:4.9.3",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.10.1"
+    "com.squareup.okhttp3:okhttp:5.0.0-alpha.4",
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.11.0"
 )
 
 javaPlatform {

--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,8 +9,7 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.11.0-alpha",
-    "io.grpc:grpc-bom:1.44.0",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.11.1-alpha",
     "org.apache.logging.log4j:log4j-bom:2.17.1",
     "software.amazon.awssdk:bom:2.17.132"
 )
@@ -18,8 +17,8 @@ val DEPENDENCY_BOMS = listOf(
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
-    "com.squareup.okhttp3:okhttp:5.0.0-alpha.4",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.11.0"
+    "com.squareup.okhttp3:okhttp:4.9.3",
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.11.1"
 )
 
 javaPlatform {

--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -3,14 +3,9 @@ plugins {
 }
 
 dependencies {
-    // TODO: Remove this when fix released upstream
-    // See here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5285
-    runtimeOnly("com.fasterxml.jackson.core:jackson-databind")
-
     runtimeOnly(project(":awssdk-autoconfigure"))
 
-    runtimeOnly("io.grpc:grpc-netty-shaded")
-    runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-1.0:1.10.1-alpha")
+    runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-events-2.2")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-logging")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp-metrics")

--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     runtimeOnly(project(":awssdk-autoconfigure"))
 
     runtimeOnly("io.grpc:grpc-netty-shaded")
-    runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-1.0")
+    runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-1.0:1.10.1-alpha")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-logging")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp-metrics")

--- a/java/layer-wrapper/scripts/otel-handler
+++ b/java/layer-wrapper/scripts/otel-handler
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
-export _HANDLER="io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestWrapper"
+export _HANDLER="io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"

--- a/java/layer-wrapper/scripts/otel-proxy-handler
+++ b/java/layer-wrapper/scripts/otel-proxy-handler
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
-export _HANDLER="io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestApiGatewayWrapper"
+export _HANDLER="io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestApiGatewayWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"

--- a/java/layer-wrapper/scripts/otel-stream-handler
+++ b/java/layer-wrapper/scripts/otel-stream-handler
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
-export _HANDLER="io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestStreamWrapper"
+export _HANDLER="io.opentelemetry.instrumentation.awslambdacore.v1_0.TracingRequestStreamWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.11.1 and other dependencies to their latest available

It also updates the `_HANDLER` for the layer scripts with available [wrappers](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/aws-lambda/aws-lambda-events-2.2/library#using-wrappers)