### PR TITLE
Lambda Layer Update : OTel Java 1.13.1

### DIFF
--- a/java/awssdk-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/AutoconfiguredTracingExecutionInterceptor.java
+++ b/java/awssdk-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/AutoconfiguredTracingExecutionInterceptor.java
@@ -6,7 +6,8 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2.autoconfigure;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTracing;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -14,19 +15,7 @@ import org.reactivestreams.Publisher;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
-import software.amazon.awssdk.core.interceptor.Context.AfterExecution;
-import software.amazon.awssdk.core.interceptor.Context.AfterMarshalling;
-import software.amazon.awssdk.core.interceptor.Context.AfterTransmission;
-import software.amazon.awssdk.core.interceptor.Context.AfterUnmarshalling;
-import software.amazon.awssdk.core.interceptor.Context.BeforeExecution;
-import software.amazon.awssdk.core.interceptor.Context.BeforeMarshalling;
-import software.amazon.awssdk.core.interceptor.Context.BeforeTransmission;
-import software.amazon.awssdk.core.interceptor.Context.BeforeUnmarshalling;
-import software.amazon.awssdk.core.interceptor.Context.FailedExecution;
-import software.amazon.awssdk.core.interceptor.Context.ModifyHttpRequest;
-import software.amazon.awssdk.core.interceptor.Context.ModifyHttpResponse;
-import software.amazon.awssdk.core.interceptor.Context.ModifyRequest;
-import software.amazon.awssdk.core.interceptor.Context.ModifyResponse;
+import software.amazon.awssdk.core.interceptor.Context;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -34,126 +23,125 @@ import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 
 /**
- * {@link ExecutionInterceptor} that delegates to {@link AwsSdkTracing}, using the autoconfigured
- * global SDK.
+ * A {@link ExecutionInterceptor} for use as an SPI by the AWS SDK to automatically trace all
+ * requests.
  */
 public class AutoconfiguredTracingExecutionInterceptor implements ExecutionInterceptor {
 
-  private final ExecutionInterceptor delegate;
+  private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
+      Config.get().getBoolean("otel.instrumentation.aws-sdk.experimental-span-attributes", false);
 
-  public AutoconfiguredTracingExecutionInterceptor() {
-    delegate =
-        AwsSdkTracing.builder(GlobalOpenTelemetry.get())
-            // TODO(anuraaga): Replace this by adding ability to configure default property values
-            // via sdk-extension-autoconfigure.
-            .setCaptureExperimentalSpanAttributes(
-                "true"
-                    .equals(
-                        System.getenv("OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES")))
-            .build()
-            .newExecutionInterceptor();
-  }
+  private final ExecutionInterceptor delegate =
+      AwsSdkTelemetry.builder(GlobalOpenTelemetry.get())
+          .setCaptureExperimentalSpanAttributes(CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES)
+          .build()
+          .newExecutionInterceptor();
 
   @Override
-  public void beforeExecution(BeforeExecution context, ExecutionAttributes executionAttributes) {
+  public void beforeExecution(
+      Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
     delegate.beforeExecution(context, executionAttributes);
   }
 
   @Override
-  public SdkRequest modifyRequest(ModifyRequest context, ExecutionAttributes executionAttributes) {
+  public SdkRequest modifyRequest(
+      Context.ModifyRequest context, ExecutionAttributes executionAttributes) {
     return delegate.modifyRequest(context, executionAttributes);
   }
 
   @Override
   public void beforeMarshalling(
-      BeforeMarshalling context, ExecutionAttributes executionAttributes) {
+      Context.BeforeMarshalling context, ExecutionAttributes executionAttributes) {
     delegate.beforeMarshalling(context, executionAttributes);
   }
 
   @Override
-  public void afterMarshalling(AfterMarshalling context, ExecutionAttributes executionAttributes) {
+  public void afterMarshalling(
+      Context.AfterMarshalling context, ExecutionAttributes executionAttributes) {
     delegate.afterMarshalling(context, executionAttributes);
   }
 
   @Override
   public SdkHttpRequest modifyHttpRequest(
-      ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
     return delegate.modifyHttpRequest(context, executionAttributes);
   }
 
   @Override
   public Optional<RequestBody> modifyHttpContent(
-      ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
     return delegate.modifyHttpContent(context, executionAttributes);
   }
 
   @Override
   public Optional<AsyncRequestBody> modifyAsyncHttpContent(
-      ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
     return delegate.modifyAsyncHttpContent(context, executionAttributes);
   }
 
   @Override
   public void beforeTransmission(
-      BeforeTransmission context, ExecutionAttributes executionAttributes) {
+      Context.BeforeTransmission context, ExecutionAttributes executionAttributes) {
     delegate.beforeTransmission(context, executionAttributes);
   }
 
   @Override
   public void afterTransmission(
-      AfterTransmission context, ExecutionAttributes executionAttributes) {
+      Context.AfterTransmission context, ExecutionAttributes executionAttributes) {
     delegate.afterTransmission(context, executionAttributes);
   }
 
   @Override
   public SdkHttpResponse modifyHttpResponse(
-      ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+      Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
     return delegate.modifyHttpResponse(context, executionAttributes);
   }
 
   @Override
   public Optional<Publisher<ByteBuffer>> modifyAsyncHttpResponseContent(
-      ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+      Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
     return delegate.modifyAsyncHttpResponseContent(context, executionAttributes);
   }
 
   @Override
   public Optional<InputStream> modifyHttpResponseContent(
-      ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
+      Context.ModifyHttpResponse context, ExecutionAttributes executionAttributes) {
     return delegate.modifyHttpResponseContent(context, executionAttributes);
   }
 
   @Override
   public void beforeUnmarshalling(
-      BeforeUnmarshalling context, ExecutionAttributes executionAttributes) {
+      Context.BeforeUnmarshalling context, ExecutionAttributes executionAttributes) {
     delegate.beforeUnmarshalling(context, executionAttributes);
   }
 
   @Override
   public void afterUnmarshalling(
-      AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
+      Context.AfterUnmarshalling context, ExecutionAttributes executionAttributes) {
     delegate.afterUnmarshalling(context, executionAttributes);
   }
 
   @Override
   public SdkResponse modifyResponse(
-      ModifyResponse context, ExecutionAttributes executionAttributes) {
+      Context.ModifyResponse context, ExecutionAttributes executionAttributes) {
     return delegate.modifyResponse(context, executionAttributes);
   }
 
   @Override
-  public void afterExecution(AfterExecution context, ExecutionAttributes executionAttributes) {
+  public void afterExecution(
+      Context.AfterExecution context, ExecutionAttributes executionAttributes) {
     delegate.afterExecution(context, executionAttributes);
   }
 
   @Override
   public Throwable modifyException(
-      FailedExecution context, ExecutionAttributes executionAttributes) {
+      Context.FailedExecution context, ExecutionAttributes executionAttributes) {
     return delegate.modifyException(context, executionAttributes);
   }
 
   @Override
-  public void onExecutionFailure(FailedExecution context, ExecutionAttributes executionAttributes) {
+  public void onExecutionFailure(
+      Context.FailedExecution context, ExecutionAttributes executionAttributes) {
     delegate.onExecutionFailure(context, executionAttributes);
   }
 }

--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.11.1-alpha",
-    "org.apache.logging.log4j:log4j-bom:2.17.1",
-    "software.amazon.awssdk:bom:2.17.132"
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.12.1-alpha",
+    "org.apache.logging.log4j:log4j-bom:2.17.2",
+    "software.amazon.awssdk:bom:2.17.164"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.9.3",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.11.1"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.12.1"
 )
 
 javaPlatform {

--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.12.1-alpha",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.13.1-alpha",
     "org.apache.logging.log4j:log4j-bom:2.17.2",
-    "software.amazon.awssdk:bom:2.17.164"
+    "software.amazon.awssdk:bom:2.17.178"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.9.3",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.12.1"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.13.1"
 )
 
 javaPlatform {

--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -11,7 +11,7 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val DEPENDENCY_BOMS = listOf(
     "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.13.1-alpha",
     "org.apache.logging.log4j:log4j-bom:2.17.2",
-    "software.amazon.awssdk:bom:2.17.178"
+    "software.amazon.awssdk:bom:2.17.179"
 )
 
 val DEPENDENCIES = listOf(

--- a/java/sample-apps/okhttp/src/main/java/io/opentelemetry/lambda/sampleapps/okhttp/OkHttpRequestHandler.java
+++ b/java/sample-apps/okhttp/src/main/java/io/opentelemetry/lambda/sampleapps/okhttp/OkHttpRequestHandler.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTracing;
+import io.opentelemetry.instrumentation.okhttp.v3_0.OkHttpTelemetry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import okhttp3.OkHttpClient;
@@ -26,7 +26,7 @@ public class OkHttpRequestHandler
 
     OkHttpClient client =
         new OkHttpClient.Builder()
-            .addInterceptor(OkHttpTracing.create(GlobalOpenTelemetry.get()).newInterceptor())
+            .addInterceptor(OkHttpTelemetry.create(GlobalOpenTelemetry.get()).newInterceptor())
             .build();
 
     APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.13.1 and other dependencies to their latest available.

Changes were made with reference to [upgrade to 0.13.1 for OTel Lambda Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/aws-sdk/aws-sdk-2.2/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/TracingExecutionInterceptor.java) 