### PR TITLE
Lambda Layer Update : OTel Java 1.14.0

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.13.1-alpha",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.14.0-alpha",
     "org.apache.logging.log4j:log4j-bom:2.17.2",
-    "software.amazon.awssdk:bom:2.17.179"
+    "software.amazon.awssdk:bom:2.17.193"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.9.3",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.13.1"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.14.0"
 )
 
 javaPlatform {


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.14.0 and other dependencies to their latest available.