### PR TITLE
Modify the OTLP-HTTP Port for NodeJS

### DIFF
--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -23,7 +23,7 @@ module "hello-lambda-function" {
     OTEL_TRACES_EXPORTER        = "logging"
     OTEL_METRICS_EXPORTER       = "logging"
     OTEL_LOG_LEVEL              = "DEBUG"
-    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:55681/v1/traces"
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/v1/traces"
   }
 
   tracing_mode = var.tracing_mode


### PR DESCRIPTION
This PR modifies the Port from `55681` to `4318`. This change was missed in the previous PR #243 

 Referenced from the PR Below.
 * https://github.com/open-telemetry/opentelemetry-js/pull/2557