### PR TITLE
Fix race on Collector.Start() loosing error info

### DIFF
--- a/collector/main.go
+++ b/collector/main.go
@@ -66,6 +66,13 @@ func processEvents(ctx context.Context, collector *Collector) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-collector.Done():
+			if err := collector.Err(); err != nil {
+				logln("Error:", err)
+			}
+			logln("Collector is done before the SHUTDOWN event")
+			logln("Exiting")
+			return
 		default:
 			logln("Waiting for event...")
 			res, err := extensionClient.NextEvent(ctx)


### PR DESCRIPTION
When the inner collector (go.opentelemetry.io/collector/service) Run() call fails
(likely due to a bad config file) the lambda collector wrapper would
likely loose the actual error information and report just the unexpected
collector state (CLOSED) back to the caller. This PR makes the collector wrapper's
Start() method race-free, so that the actual error information is not
lost.

Another improvement is related to the main() procedure - before this PR the main loop
wouldn't handle situations when the inner collector exits before the
SHUTDOWN event.