### PR TITLE
Lambda Layer Update : OTel Java 1.15.0

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.14.0-alpha",
-    "org.apache.logging.log4j:log4j-bom:2.17.2",
-    "software.amazon.awssdk:bom:2.17.193"
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.15.0-alpha",
+    "org.apache.logging.log4j:log4j-bom:2.18.0",
+    "software.amazon.awssdk:bom:2.17.226"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
-    "com.squareup.okhttp3:okhttp:4.9.3",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.14.0"
+    "com.squareup.okhttp3:okhttp:4.10.0",
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.15.0"
 )
 
 javaPlatform {

--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     runtimeOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-events-2.2")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-logging")
     runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
-    runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp-metrics")
     runtimeOnly("io.opentelemetry:opentelemetry-extension-trace-propagators")
     runtimeOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
     runtimeOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.15.0 and other dependencies to their latest available. This also includes the deprecated/merged deps.

Reference :

 * https://github.com/open-telemetry/opentelemetry-java/releases