### PR TITLE
Update JS Endpoint + use go1.17 in go.mod for collector

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector
 
-go 1.18
+go 1.17
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents => ./lambdacomponents
 

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents
 
-go 1.18
+go 1.17
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.54.0

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -23,7 +23,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",

--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -23,7 +23,7 @@ module "hello-lambda-function" {
     OTEL_TRACES_EXPORTER        = "logging"
     OTEL_METRICS_EXPORTER       = "logging"
     OTEL_LOG_LEVEL              = "DEBUG"
-    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/v1/traces"
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/"
   }
 
   tracing_mode = var.tracing_mode


### PR DESCRIPTION
This PR updates the JS endpoint with the respective to the recent changes made in JS SDK to match spec.
 
  * https://github.com/open-telemetry/opentelemetry-js/pull/2895
  * https://github.com/open-telemetry/opentelemetry-js/issues/2816#issuecomment-1090501716 - SIG Meeting reference

Use Go1.17 in go.mod to match with the opentelemetry-collector

* https://github.com/open-telemetry/opentelemetry-collector/blob/main/go.mod#L3
* Use `go mod tidy compat=1.17` 
* https://github.com/open-telemetry/opentelemetry-collector/pull/4810

