### PR TITLE
Lambda Layer Update : OTel Java 1.16.0

### DIFF
--- a/java/awssdk-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/AutoconfiguredTracingExecutionInterceptor.java
+++ b/java/awssdk-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/autoconfigure/AutoconfiguredTracingExecutionInterceptor.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2.autoconfigure;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.instrumentation.awssdk.v2_2.AwsSdkTelemetry;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -29,7 +29,8 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 public class AutoconfiguredTracingExecutionInterceptor implements ExecutionInterceptor {
 
   private static final boolean CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES =
-      Config.get().getBoolean("otel.instrumentation.aws-sdk.experimental-span-attributes", false);
+      ConfigPropertiesUtil.getBoolean(
+          "otel.instrumentation.aws-sdk.experimental-span-attributes", false);
 
   private final ExecutionInterceptor delegate =
       AwsSdkTelemetry.builder(GlobalOpenTelemetry.get())

--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.15.0-alpha",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.16.0-alpha",
     "org.apache.logging.log4j:log4j-bom:2.18.0",
     "software.amazon.awssdk:bom:2.17.226"
 )
@@ -18,7 +18,7 @@ val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.10.0",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.15.0"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.16.0"
 )
 
 javaPlatform {


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.16.0 and other dependencies to their latest available.