### PR TITLE
Pin protobuf to 3.20.0 in python layer

### DIFF
--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -3,13 +3,13 @@ name: "Pull Request (Python)"
 on:
   pull_request:
     paths:
-    - 'python/**'
+      - 'python/**'
     branches:
       - main
 
 env:
   AWS_REGION: us-east-1
-  CORE_REPO_SHA: 281c97bf8f9e31392859e006e13c9c8eac8967c3
+  CORE_REPO_SHA: e45d833bd06b9309ce82f8e6085eeb2b7948edad
 
 jobs:
   PR-Python:

--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  CORE_REPO_SHA: e45d833bd06b9309ce82f8e6085eeb2b7948edad
 
 jobs:
   PR-Python:

--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,3 +1,4 @@
 opentelemetry-exporter-otlp-proto-http==1.11.1
 opentelemetry-distro==0.30b1
 opentelemetry-instrumentation-aws-lambda==0.30b1
+protobuf==3.20.0


### PR DESCRIPTION
The PR pins protobuf to 3.20.0 in python Layer. This is being done as a work around till the fix is released in OpenTelemetry-python

 * https://github.com/open-telemetry/opentelemetry-python/issues/2717
 
 Follow up will be created to track in this repo.