### PR TITLE
Lambda Layer Update - OTel Java 1.17.0

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.16.0-alpha",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.17.0-alpha",
     "org.apache.logging.log4j:log4j-bom:2.18.0",
-    "software.amazon.awssdk:bom:2.17.226"
+    "software.amazon.awssdk:bom:2.17.263"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.10.0",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.16.0"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.17.0"
 )
 
 javaPlatform {


### PR DESCRIPTION
**Description**

This PR updates OTel Java dependencies to 1.15.0 and other dependencies to their latest available. 

Reference :

https://github.com/open-telemetry/opentelemetry-java/releases

**Testing**
<img width="1422" alt="Screen Shot 2022-08-31 at 10 31 59 AM" src="https://user-images.githubusercontent.com/28486681/187742465-fd7e8cfd-aa25-4d0b-987b-7384f0fde014.png">

