### PR TITLE
Use requests for python sample app

### DIFF
--- a/python/sample-apps/function/lambda_function.py
+++ b/python/sample-apps/function/lambda_function.py
@@ -8,7 +8,7 @@ s3 = boto3.resource("s3")
 # lambda function
 def lambda_handler(event, context):
 
-    requests.get("https://www.amazon.com/")
+    requests.get("http://httpbin.org/")
 
     for bucket in s3.buckets.all():
         print(bucket.name)

--- a/python/sample-apps/function/lambda_function.py
+++ b/python/sample-apps/function/lambda_function.py
@@ -1,26 +1,14 @@
 import os
 import json
-import aiohttp
-import asyncio
 import boto3
-
-
-async def fetch(session, url):
-    async with session.get(url) as response:
-        return await response.text()
-
-
-async def callAioHttp():
-    async with aiohttp.ClientSession() as session:
-        html = await fetch(session, "http://httpbin.org/")
+import requests
 
 s3 = boto3.resource("s3")
 
 # lambda function
 def lambda_handler(event, context):
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(callAioHttp())
+    requests.get("https://www.amazon.com/")
 
     for bucket in s3.buckets.all():
         print(bucket.name)

--- a/python/sample-apps/function/requirements.txt
+++ b/python/sample-apps/function/requirements.txt
@@ -1,1 +1,1 @@
-aiohttp
+requests


### PR DESCRIPTION
Aiohttp is causing a regression in the soak tests downstream, causing high CPU usage.

The regression is caused by a bug inserted  in this commit: https://github.com/open-telemetry/opentelemetry-python-contrib/commit/e267ebc64518d82ed52c3da0681213beae3c1d95

The bug was fixed in this commit and will only be available in the next release: https://github.com/open-telemetry/opentelemetry-python-contrib/commit/934af7ea4f9b1e0294ced6a014d6eefdda156b2b

In order to unblock the soak tests, I'm suggesting that we move to use requests instead of aiohttp.