### PR TITLE
Add B3 propagation

### DIFF
--- a/python/src/otel/otel_sdk/requirements-nodeps.txt
+++ b/python/src/otel/otel_sdk/requirements-nodeps.txt
@@ -1,3 +1,4 @@
+opentelemetry-propagator-b3==1.12.0
 opentelemetry-instrumentation-aiohttp-client==0.33b0
 opentelemetry-util-http==0.33b0
 asgiref~=3.0


### PR DESCRIPTION
We want to use B3 propagation with AWS lambda and from documentation it seems that it's not currently possible