### PR TITLE
Java layer-wrapper script for SQS-triggerd functions

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -2,8 +2,9 @@
 
 Layers for running Java applications on AWS Lambda with OpenTelemetry.
 
-## Prerequisites 
-- Supports Lambda functions using Java 11 (Corretto) runtime only. 
+## Prerequisites
+
+- Supports Lambda functions using Java 11 (Corretto) runtime only.
 
 ## Provided layers
 
@@ -21,6 +22,7 @@ generally need to use this along with provisioned concurrency and warmup request
 requests without causing timeouts on initial requests while it initializes.
 
 ### Wrapper
+
 [OpenTelemetry Lambda Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/aws-lambda-1.0/library)
 and [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-java) are bundled into the
 `java/lib` directory to be available on the classpath of the Lambda function. No code change is
@@ -28,6 +30,7 @@ needed to instrument the execution of your function, but you will need to set th
 environment variable pointing to the appropriate wrapper for the type of handler.
 
 - `/opt/otel-handler` - for wrapping regular handlers (implementing RequestHandler)
+- `/opt/otel-sqs-handler` - for wrapping SQS-triggered function handlers (implementing RequestHandler)
 - `/opt/otel-proxy-handler` - for wrapping regular handlers (implementing RequestHandler) proxied through API Gateway, enabling HTTP context propagation
 - `/opt/otel-stream-handler` - for wrapping streaming handlers (implementing RequestStreamHandler), enabling HTTP context propagation for HTTP requests
 
@@ -61,8 +64,8 @@ The layer zip file will be present at `./layer-wrapper/build/distributions/opent
 Sample applications are provided to show usage the above layers.
 
 - [Application using AWS SDK](./sample-apps/aws-sdk) - shows how both the wrapper and agent can be used
-with an application using AWS SDK without code change.
+  with an application using AWS SDK without code change.
 
 - [Application using OkHttp](./sample-apps/okhttp) - shows the manual initialization of OkHttp
-library instrumentation for use with the wrapper. The agent would be usable without such a code change
-at the expense of the cold start overhead it introduces.
+  library instrumentation for use with the wrapper. The agent would be usable without such a code change
+  at the expense of the cold start overhead it introduces.

--- a/java/layer-wrapper/scripts/otel-sqs-handler
+++ b/java/layer-wrapper/scripts/otel-sqs-handler
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
+export _HANDLER="io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingSqsEventWrapper"
+
+if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
+  export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000
+
+exec "$@"

--- a/java/sample-apps/sqs/README.md
+++ b/java/sample-apps/sqs/README.md
@@ -1,0 +1,33 @@
+# Amazon SQS Sample App
+
+This application includes a Lambda with an SQS queue as an event source. You can find
+deployment scripts using Terraform that are configured to deploy this sample app to AWS Lambda while publishing and using the OpenTelemetry layers.
+
+## Requirements
+
+- Java for building this repository
+- [Terraform](https://www.terraform.io/downloads.html)
+- AWS credentials, either using environment variables or via the CLI and `aws configure`
+
+First, in the `java` subfolder of this repository, build all the artifacts.
+
+```
+./gradlew build
+```
+
+Then, decide if you want to try the wrapper or the agent version. Navigate to the appropriate
+subfolder of [deploy](./deploy) and deploy with Terraform.
+
+```
+terraform init
+terraform apply
+```
+
+For the agent version, to change the configuration of the OpenTelemetry collector, you can provide the ARN of a Lambda layer with a custom collector configuration in a file named `config.yaml` when prompted after running the `terraform apply` command.
+
+After deployment, login to AWS and test the Lambda function using the predefined SQS test payload. The agent version tends to take 10-20s for the first request, while the wrapper version tends to take 5-10s. Confirm
+that spans are logged in the CloudWatch logs for the function on the AWS Console either for the
+[wrapper](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fhello-awssdk-java-wrapper)
+or for the [agent](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fhello-awssdk-javaagent).
+
+If you already have an SQS queue to test with, uncomment the commented sections at the bottom of the `main.tf` and `variables.tf` files and then provide the ARN for your queue when running `terraform apply`. You will then need to publish a message to the queue to test the Lambda function.

--- a/java/sample-apps/sqs/build.gradle.kts
+++ b/java/sample-apps/sqs/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    java
+    id("com.github.johnrengelman.shadow")
+}
+
+dependencies {
+    implementation("com.amazonaws:aws-lambda-java-core")
+    implementation("com.amazonaws:aws-lambda-java-events")
+    implementation("org.apache.logging.log4j:log4j-core")
+
+    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl")
+}
+
+tasks {
+    assemble {
+        dependsOn("shadowJar")
+    }
+}

--- a/java/sample-apps/sqs/deploy/agent/main.tf
+++ b/java/sample-apps/sqs/deploy/agent/main.tf
@@ -1,0 +1,57 @@
+module "hello-lambda-function" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = ">= 2.24.0"
+
+  architectures = compact([var.architecture])
+  function_name = var.name
+  handler       = "io.opentelemetry.lambda.sampleapps.sqs.SqsRequestHandler::handleRequest"
+  runtime       = "java11"
+
+  create_package         = false
+  local_existing_package = "${path.module}/../../build/libs/sqs-all.jar"
+
+  memory_size = 512
+  timeout     = 120
+  publish     = true
+
+  layers = compact([
+    var.collector_layer_arn,
+    var.sdk_layer_arn,
+    var.collector_config_layer_arn,
+  ])
+
+  environment_variables = (var.collector_config_layer_arn == null ?
+    {
+      AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler",
+      OTEL_METRICS_EXPORTER   = "otlp",
+    } :
+    {
+      AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
+      OTEL_METRICS_EXPORTER               = "otlp",
+      OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/opt/config.yaml"
+  })
+
+  tracing_mode = var.tracing_mode
+
+  # UNCOMMENT BELOW TO TEST WITH YOUR SQS QUEUE
+  # policy_statements = {
+  #   sqs_read = {
+  #     effect    = "Allow",
+  #     actions   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+  #     resources = [var.sqs_queue_arn]
+  #   }
+  # }
+
+  # event_source_mapping = {
+  #   sqs_queue = {
+  #     event_source_arn = var.sqs_queue_arn
+  #   }
+  # }
+
+  # allowed_triggers = {
+  #   sqs_queue = {
+  #     principal  = "sqs.amazonaws.com"
+  #     source_arn = "${var.sqs_queue_arn}"
+  #   }
+  # }
+}

--- a/java/sample-apps/sqs/deploy/agent/outputs.tf
+++ b/java/sample-apps/sqs/deploy/agent/outputs.tf
@@ -1,0 +1,3 @@
+output "function_role_name" {
+  value = module.hello-lambda-function.lambda_role_name
+}

--- a/java/sample-apps/sqs/deploy/agent/variables.tf
+++ b/java/sample-apps/sqs/deploy/agent/variables.tf
@@ -1,0 +1,40 @@
+variable "name" {
+  type        = string
+  description = "Name of created function and API Gateway"
+  default     = "hello-java-awssdk-agent"
+}
+
+variable "collector_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry collector extension"
+  // TODO(anuraaga): Add default when a public layer is published.
+}
+
+variable "collector_config_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry collector configuration file"
+}
+
+variable "sdk_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry Java Agent"
+  // TODO(anuraaga): Add default when a public layer is published.
+}
+
+variable "tracing_mode" {
+  type        = string
+  description = "Lambda function tracing mode"
+  default     = "PassThrough"
+}
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}
+
+# UNCOMMENT BELOW TO TEST WITH YOUR SQS QUEUE
+# variable "sqs_queue_arn" {
+#   type        = string
+#   description = "ARN for the SQS queue to use an event source for the Lambda"
+# }

--- a/java/sample-apps/sqs/deploy/wrapper/main.tf
+++ b/java/sample-apps/sqs/deploy/wrapper/main.tf
@@ -1,0 +1,48 @@
+module "hello-lambda-function" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = ">= 2.24.0"
+
+  architectures = compact([var.architecture])
+  function_name = var.name
+  handler       = "io.opentelemetry.lambda.sampleapps.sqs.SqsRequestHandler::handleRequest"
+  runtime       = "java11"
+
+  create_package         = false
+  local_existing_package = "${path.module}/../../build/libs/sqs-all.jar"
+
+  memory_size = 384
+  timeout     = 20
+
+  layers = compact([
+    var.collector_layer_arn,
+    var.sdk_layer_arn
+  ])
+
+  environment_variables = {
+    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-sqs-handler"
+  }
+
+  tracing_mode = var.tracing_mode
+
+  # UNCOMMENT BELOW TO TEST WITH YOUR SQS QUEUE
+  # policy_statements = {
+  #   sqs_read = {
+  #     effect    = "Allow",
+  #     actions   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+  #     resources = [var.sqs_queue_arn]
+  #   }
+  # }
+
+  # event_source_mapping = {
+  #   sqs_queue = {
+  #     event_source_arn = var.sqs_queue_arn
+  #   }
+  # }
+
+  # allowed_triggers = {
+  #   sqs_queue = {
+  #     principal  = "sqs.amazonaws.com"
+  #     source_arn = "${var.sqs_queue_arn}"
+  #   }
+  # }
+}

--- a/java/sample-apps/sqs/deploy/wrapper/outputs.tf
+++ b/java/sample-apps/sqs/deploy/wrapper/outputs.tf
@@ -1,0 +1,3 @@
+output "function_role_name" {
+  value = module.hello-lambda-function.lambda_role_name
+}

--- a/java/sample-apps/sqs/deploy/wrapper/variables.tf
+++ b/java/sample-apps/sqs/deploy/wrapper/variables.tf
@@ -1,0 +1,35 @@
+variable "name" {
+  type        = string
+  description = "Name of created function and API Gateway"
+  default     = "hello-java-awssdk-wrapper"
+}
+
+variable "collector_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry collector extension"
+  // TODO(anuraaga): Add default when a public layer is published.
+}
+
+variable "sdk_layer_arn" {
+  type        = string
+  description = "ARN for the Lambda layer containing the OpenTelemetry Java Wrapper"
+  // TODO(anuraaga): Add default when a public layer is published.
+}
+
+variable "tracing_mode" {
+  type        = string
+  description = "Lambda function tracing mode"
+  default     = "PassThrough"
+}
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, valid values are arm64 or x86_64"
+  default     = "x86_64"
+}
+
+# UNCOMMENT BELOW TO TEST WITH YOUR SQS QUEUE
+# variable "sqs_queue_arn" {
+#   type        = string
+#   description = "ARN for the SQS queue to use an event source for the Lambda"
+# }

--- a/java/sample-apps/sqs/src/main/java/io/opentelemetry/lambda/sampleapps/sqs/SqsRequestHandler.java
+++ b/java/sample-apps/sqs/src/main/java/io/opentelemetry/lambda/sampleapps/sqs/SqsRequestHandler.java
@@ -1,0 +1,25 @@
+package io.opentelemetry.lambda.sampleapps.sqs;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SqsRequestHandler implements RequestHandler<SQSEvent, Void> {
+
+  private static final Logger logger = LogManager.getLogger(SqsRequestHandler.class);
+
+  @Override
+  public Void handleRequest(SQSEvent event, Context context) {
+    logger.info("Processing message(s) from SQS");
+
+    for (SQSMessage msg : event.getRecords()) {
+      logger.info("SOURCE QUEUE: " + msg.getEventSourceArn());
+      logger.info("MESSAGE: " + msg.getBody());
+    }
+
+    return null;
+  }
+}

--- a/java/sample-apps/sqs/src/main/resources/log4j2.xml
+++ b/java/sample-apps/sqs/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/java/settings.gradle.kts
+++ b/java/settings.gradle.kts
@@ -19,5 +19,6 @@ include(":layer-javaagent")
 include(":layer-wrapper")
 include(":sample-apps:aws-sdk")
 include(":sample-apps:okhttp")
+include(":sample-apps:sqs")
 
 rootProject.name = "opentelemetry-lambda-java"


### PR DESCRIPTION
The current Java wrapper Lamdba layer drops the SQS message before it gets to the handler. This update enables the special handler for SQS-triggered functions as [documented here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/f236b2d4c9a0813b2dddf3d35928c79b21beb6d5/instrumentation/aws-lambda/aws-lambda-events-2.2/library). 