### PR TITLE
Lambda Layer Update : OTel Java 1.18.0

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.17.0-alpha",
-    "org.apache.logging.log4j:log4j-bom:2.18.0",
-    "software.amazon.awssdk:bom:2.17.263"
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.18.0-alpha",
+    "org.apache.logging.log4j:log4j-bom:2.19.0",
+    "software.amazon.awssdk:bom:2.17.276"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.10.0",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.17.0"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.18.0"
 )
 
 javaPlatform {


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.18.0 and other dependencies to their latest available.

Testing:
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/41936996/191821645-67774389-4a50-4295-a481-e93f847612f2.png">

