### PR TITLE
Lambda Layer Update : OTel Java 1.19.1

### DIFF
--- a/java/dependencyManagement/build.gradle.kts
+++ b/java/dependencyManagement/build.gradle.kts
@@ -9,16 +9,16 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.18.0-alpha",
+    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.19.1-alpha",
     "org.apache.logging.log4j:log4j-bom:2.19.0",
-    "software.amazon.awssdk:bom:2.17.276"
+    "software.amazon.awssdk:bom:2.18.3"
 )
 
 val DEPENDENCIES = listOf(
     "com.amazonaws:aws-lambda-java-core:1.2.1",
     "com.amazonaws:aws-lambda-java-events:3.11.0",
     "com.squareup.okhttp3:okhttp:4.10.0",
-    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.18.0"
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.19.1"
 )
 
 javaPlatform {


### PR DESCRIPTION
This PR updates OTel Java dependencies to 1.19.1 and other dependencies to their latest available.

![image](https://user-images.githubusercontent.com/41936996/198105733-bddf9c21-6c4e-47c1-82b1-725ffe13f9ee.png)
