### PR TITLE
Add configureInstrumentations to configure instrumentation outside of wrapper

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -18,10 +18,33 @@ npm install
 
 This will download all dependencies and compile all code. The layer zip file will be present at `./packages/layer/build/layer.zip`.
 
+## Configuration
+
+Within `packages/layer/src/wrapper.ts`, there are various hooks that can be used to configure tracing.
+
+For each feature (e.g., Tracer, TracerProvider, etc.) to configure, declare the corresponding `configure` function in a file that should be `--require`'d via the Lambda's `NODE_OPTIONS` environment variable.
+
+A full list of configure functions can be found at `packages/layer/src/wrapper.ts`.
+
+
+e.g., To configure the instrumentations to register:
+1. Create a file,`configuration.ts`:
+```javascript
+declare global {
+  function configureInstrumentations(): InstrumentationOption[];
+}
+
+global.configureInstrumentations = () => {
+  return [new HttpInstrumentation()];
+};
+```
+
+2. Set the `NODE_OPTIONS` environment variable on your lambda to the _compiled file_ `--require ./path/to/configuration.js`
+
 ## Sample applications
 
 Sample applications are provided to show usage of the above layer.
 
 - Application using AWS SDK - shows using the wrapper with an application using AWS SDK without code change.
   - [Using layer built from source](./integration-tests/aws-sdk)
-  - [WIP] [Using OTel Public Layer](./sample-apps/aws-sdk) 
+  - [WIP] [Using OTel Public Layer](./sample-apps/aws-sdk)

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -5,7 +5,7 @@ import {
   SDKRegistrationConfig,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { InstrumentationBase, registerInstrumentations } from '@opentelemetry/instrumentation';
 import { awsLambdaDetector } from '@opentelemetry/resource-detector-aws';
 import {
   detectResources,
@@ -47,11 +47,12 @@ declare global {
     defaultSdkRegistration: SDKRegistrationConfig
   ): SDKRegistrationConfig;
   function configureLambdaInstrumentation(config: AwsLambdaInstrumentationConfig): AwsLambdaInstrumentationConfig
+  function configureInstrumentations(instrumentations: InstrumentationBase[]): InstrumentationBase[]
 }
 
 console.log('Registering OpenTelemetry');
 
-const instrumentations = [
+const baseInstrumentations = [
   new AwsInstrumentation({
     suppressInternalInstrumentation: true,
   }),
@@ -74,6 +75,8 @@ const instrumentations = [
 // configure lambda logging
 const logLevel = getEnv().OTEL_LOG_LEVEL
 diag.setLogger(new DiagConsoleLogger(), logLevel)
+
+const instrumentations = (typeof configureInstrumentations === 'function' ? configureInstrumentations(baseInstrumentations) : baseInstrumentations);
 
 // Register instrumentations synchronously to ensure code is patched even before provider is ready.
 registerInstrumentations({


### PR DESCRIPTION
Would be nice to be able to configure the instrumentations included by the layer, as well as add/remove instrumentations.

This is a small PR that adds that hook, as well as adds a little note in the README as to how to use the hooks. 