### PR TITLE
[chore] enable dependabot for the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/collector"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/java"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/nodejs"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "auto"
+  - package-ecosystem: "pip"
+    directory: "/python/src/otel/otel_sdk"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Will need to see dependabot running to ensure the configuration is correct as i've not used it with npm/java before.