### PR TITLE
[chore] tox configuration no longer valid

### DIFF
--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -11,7 +11,7 @@ env:
   AWS_REGION: us-east-1
   # Copied this CORE_REPO_SHA from
   # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/workflows/test.yml#L9
-  CORE_REPO_SHA: 2ac9e646af8d6420f13e7e3b2508586f3efb435a
+  CORE_REPO_SHA: v1.14.0
 
 jobs:
   PR-Python:

--- a/python/src/tox.ini
+++ b/python/src/tox.ini
@@ -23,7 +23,7 @@ changedir =
     test-instrumentation-aws-lambda: {toxinidir}/otel/tests
 
 commands_pre =
-    test: pip install "opentelemetry-test-utils @ {env:CORE_REPO}#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils"
+    test: pip install "opentelemetry-test-utils[test] @ {env:CORE_REPO}\#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils"
 
     aws-lambda: pip install opentelemetry-instrumentation-aws-lambda
 


### PR DESCRIPTION
The new version of tox interprets # as a comment. Additionally, test-utils requires a few additional packages.

Signed-off-by: Alex Boten <aboten@lightstep.com>