### PR TITLE
[chore] make all shell scripts pass shellcheck

### DIFF
--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
+set -e
 
 GOARCH=${GOARCH-amd64}
 
 # Chosen from Microsoft's documentation for Runtime Identifier (RIDs)
 # See more: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#linux-rids
-if [ $GOARCH = "amd64" ]; then
+if [ "$GOARCH" = "amd64" ]; then
     DOTNET_LINUX_ARCH=x64
-elif [ $GOARCH = "arm64" ]; then
+elif [ "$GOARCH" = "arm64" ]; then
     DOTNET_LINUX_ARCH=arm64
 else
-    echo "Invalid GOARCH value `$GOARCH` received."
+    echo "Invalid GOARCH value $(GOARCH) received."
     exit 2
 fi
 
@@ -20,5 +21,5 @@ dotnet publish \
     --framework "netcoreapp3.1" /p:GenerateRuntimeConfigurationFiles=true \
     --runtime linux-$DOTNET_LINUX_ARCH \
     --self-contained false
-cd build/dotnet || exit
-zip -r ../function.zip *
+cd build/dotnet
+zip -r ../function.zip ./*

--- a/go/sample-apps/function/build.sh
+++ b/go/sample-apps/function/build.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+set -e
 
 GOARCH=${GOARCH-amd64}
 
 mkdir -p build
 GOOS=linux go build -o ./build/bootstrap .
-cd build || exit
+cd build
 zip bootstrap.zip bootstrap

--- a/python/sample-apps/build.sh
+++ b/python/sample-apps/build.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
+set -e
 
 mkdir -p build/python
 python3 -m pip install -r function/requirements.txt -t build/python
 cp function/lambda_function.py -t build/python
-cd build/python || exit
-zip -r ../function.zip *
+cd build/python
+zip -r ../function.zip ./*

--- a/python/sample-apps/run.sh
+++ b/python/sample-apps/run.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 cp -r ../src/otel .
 cp ../src/run.sh layer.sh
 ./layer.sh "$@"

--- a/python/src/build.sh
+++ b/python/src/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 mkdir -p build
 docker build -t aws-otel-lambda-python-layer otel

--- a/utils/sam/run.sh
+++ b/utils/sam/run.sh
@@ -24,7 +24,7 @@ is_sample() {
 
 main() {
 	echo "running..."
-	saved_args="$@"
+	saved_args="$*"
 	template='template.yml'
 	build=false
 	deploy=false
@@ -37,7 +37,7 @@ main() {
 
 	collectorPath=${COLLECTOR_PATH-"../../collector"}
 
-	while getopts "hbdxlr:t:s:n:" opt; do
+	while getopts "hbdlr:t:s:n:" opt; do
 		case "${opt}" in
 		h)
 			echo_usage
@@ -87,27 +87,27 @@ main() {
 		echo "sam building..."
 
 		echo "run.sh: building the collector..."
-		pushd $collectorPath || exit
+		pushd "$collectorPath"
 		make package
 		rm build/collector-extension.zip
-		popd || exit
+		popd
 		rm -rf otel/collector_build/
-		cp -r $collectorPath/build/ otel/collector_build/
+		cp -r "$collectorPath"/build/ otel/collector_build/
 
 		echo "run.sh: Starting sam build."
-		sam build -u -t $template
+		sam build -u -t "$template"
 	fi
 
 	if [[ $deploy == true ]]; then
-		sam deploy --stack-name $stack --region $region --capabilities CAPABILITY_NAMED_IAM --resolve-s3 --parameter-overrides LayerName=$layerName
+		sam deploy --stack-name "$stack" --region "$region" --capabilities CAPABILITY_NAMED_IAM --resolve-s3 --parameter-overrides LayerName="$layerName"
 		rm -rf otel/otel_collector
 		rm -rf .aws-sam
 	fi
 
 	if [[ $layer == true ]]; then
 		echo -e "\nOTel Lambda layer ARN:"
-		arn=$(aws lambda list-layer-versions --layer-name $layerName --region $region --query 'max_by(LayerVersions, &Version).LayerVersionArn')
-		echo $arn | sed 's/\"//g'
+		arn=$(aws lambda list-layer-versions --layer-name "$layerName" --region "$region" --query 'max_by(LayerVersions, &Version).LayerVersionArn')
+		echo "${arn//\"/}"
 	fi
 }
 


### PR DESCRIPTION
Make all shell scripts pass `shellcheck`:
- use `set -e` for all scripts and drop `command || exit` syntax
- Fix all default shellcheck warnings/errors

Happy to also contribute a PR to do shellcheck in CI if folks want.