### PR TITLE
Usage of dotnet 6 framework runtime in TF scripts

### DIFF
--- a/dotnet/integration-tests/aws-sdk/wrapper/main.tf
+++ b/dotnet/integration-tests/aws-sdk/wrapper/main.tf
@@ -2,7 +2,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../collector/build/collector-extension.zip"
-  compatible_runtimes = ["dotnetcore2.1", "dotnetcore3.1"]
+  compatible_runtimes = ["dotnet6", "dotnetcore3.1"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../collector/build/collector-extension.zip")
 }

--- a/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -5,7 +5,7 @@ module "hello-lambda-function" {
   architectures = compact([var.architecture])
   function_name = var.name
   handler       = "AwsSdkSample::AwsSdkSample.Function::TracingFunctionHandler"
-  runtime       = "dotnetcore3.1"
+  runtime       = "dotnet6"
 
   create_package         = false
   local_existing_package = "${path.module}/../../wrapper/SampleApps/build/function.zip"

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.01</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.01</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Properties/launchSettings.json
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
       "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe"
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
     }
   }
 }

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Properties/launchSettings.json
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\netcoreapp3.1",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
       "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe"
     }
   }

--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
+++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
@@ -18,7 +18,7 @@ mkdir -p build/dotnet
 dotnet publish \
     --output "./build/dotnet" \
     --configuration "Release" \
-    --framework "netcoreapp3.1" /p:GenerateRuntimeConfigurationFiles=true \
+    --framework "net6.0" /p:GenerateRuntimeConfigurationFiles=true \
     --runtime linux-$DOTNET_LINUX_ARCH \
     --self-contained false
 cd build/dotnet


### PR DESCRIPTION
Description: 

This PR is created to test in dotnet 6 runtime and deprecate testing in `dotnet2.1`. Currently the supported runtimes in AWS Lambda are as below.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/41936996/213254084-69f13e70-00a9-4274-8527-76a0fb936bde.png">

Testing:

The changes were tested and following is the trace map in AWS X-Ray.
 
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/41936996/213253565-c977d7f1-4254-44eb-b6ba-25f45d6cb4f4.png">

Follow up PR in downstream : 