### PR TITLE
feat: add faas.instance resource attribute for python

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -133,7 +133,7 @@ fi
 #       )
 #   )
 
-export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION";
+export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,faas.instance=$AWS_LAMBDA_LOG_STREAM_NAME";
 
 if [ -z "${OTEL_RESOURCE_ATTRIBUTES}" ]; then
     export OTEL_RESOURCE_ATTRIBUTES=$LAMBDA_RESOURCE_ATTRIBUTES;


### PR DESCRIPTION
Hey folks!

I've would like to add faas.instance resource attribute to the python autoinstrumentation. This is defined in: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/faas.md#faas-resource-attributes

AWS docs for that environment variable:

https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
