### PR TITLE
Use non-conflicting port for Telemetry API listener

### DIFF
--- a/collector/internal/telemetryapi/listener.go
+++ b/collector/internal/telemetryapi/listener.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultListenerPort = "4323"
+const defaultListenerPort = "53612"
 const initialQueueSize = 5
 
 // Listener is used to listen to the Telemetry API

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -106,7 +106,7 @@ func TestHandler(t *testing.T) {
 			)
 			require.NoError(t, err)
 			req := httptest.NewRequest("POST",
-				"http://localhost:4323/someevent", strings.NewReader(tc.body))
+				"http://localhost:53612/someevent", strings.NewReader(tc.body))
 			rec := httptest.NewRecorder()
 			r.httpHandler(rec, req)
 			require.Equal(t, tc.expectedSpans, consumer.consumed)


### PR DESCRIPTION
The current port may conflict with the `cloudwatch_lambda_agent` layer.

Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>