### PR TITLE
Support for node18.x runtime and remove nodejs12.x

### DIFF
--- a/collector/Makefile
+++ b/collector/Makefile
@@ -30,7 +30,7 @@ publish-layer: package
 	@echo Publishing collector extension layer...
 	aws s3 mb s3://$(BUCKET_NAME)
 	aws s3 cp $(BUILD_SPACE)/collector-extension.zip s3://$(BUCKET_NAME)
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --content S3Bucket=$(BUCKET_NAME),S3Key=collector-extension.zip --compatible-runtimes nodejs12.x nodejs14.x nodejs16.x java11 python3.8 python3.9 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --content S3Bucket=$(BUCKET_NAME),S3Key=collector-extension.zip --compatible-runtimes nodejs14.x nodejs16.x nodejs18.x java11 python3.8 python3.9 --query 'LayerVersionArn' --output text
 	@echo Clearing cached files...
 	aws s3 rm s3://$(BUCKET_NAME)/collector-extension.zip
 	aws s3 rb s3://$(BUCKET_NAME)

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../collector/build/collector-extension.zip"
-  compatible_runtimes = ["nodejs12.x", "nodejs14.x", "nodejs16.x"]
+  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../collector/build/collector-extension.zip")
 }

--- a/java/integration-tests/aws-sdk/wrapper/main.tf
+++ b/java/integration-tests/aws-sdk/wrapper/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../collector/build/collector-extension.zip"
-  compatible_runtimes = ["nodejs12.x", "nodejs14.x", "nodejs16.x"]
+  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../collector/build/collector-extension.zip")
 }

--- a/java/integration-tests/okhttp/wrapper/main.tf
+++ b/java/integration-tests/okhttp/wrapper/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../collector/build/collector-extension.zip"
-  compatible_runtimes = ["nodejs12.x", "nodejs14.x", "nodejs16.x"]
+  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../collector/build/collector-extension.zip")
 }

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_layer_version" "sdk_layer" {
   layer_name          = var.sdk_layer_name
   filename            = "${path.module}/../../../packages/layer/build/layer.zip"
-  compatible_runtimes = ["nodejs12.x", "nodejs14.x", "nodejs16.x"]
+  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../packages/layer/build/layer.zip")
 }
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../collector/build/collector-extension.zip"
-  compatible_runtimes = ["nodejs12.x", "nodejs14.x", "nodejs16.x"]
+  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../collector/build/collector-extension.zip")
 }

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -23,7 +23,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.2.0",

--- a/nodejs/sample-apps/aws-sdk/package.json
+++ b/nodejs/sample-apps/aws-sdk/package.json
@@ -26,7 +26,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../collector/build/collector-extension.zip"
-  compatible_runtimes = ["nodejs12.x", "nodejs14.x", "nodejs16.x"]
+  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../collector/build/collector-extension.zip")
 }


### PR DESCRIPTION
This PR is created to add support of nodejs18.x version and removes the support of node12.x/node 12 and below.

Supported [Node Runtimes](https://github.com/open-telemetry/opentelemetry-js#supported-runtimes) in OTel-JS

node js 18.x support https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/382