### PR TITLE
fix: format shell script and set option

### DIFF
--- a/utils/sam/run.sh
+++ b/utils/sam/run.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -u
+set -o pipefail
 
 echo_usage() {
 	echo "usage: Deploy Lambda layer/application by SAM"
@@ -33,7 +34,6 @@ main() {
 	region=${AWS_REGION-$(aws configure get region)}
 	stack=${OTEL_LAMBDA_STACK-"otel-stack"}
 	layerName=${OTEL_LAMBDA_LAYER-"otel-layer"}
-
 
 	collectorPath=${COLLECTOR_PATH-"../../collector"}
 


### PR DESCRIPTION
Remove extra space and set pipefail option

set -o pipefail
This setting prevents errors in a pipeline from being masked. If any command in a pipeline fails, that return code will be used as the return code of the whole pipeline. By default, the pipeline's return code is that of the last command even if it succeeds.