### PR TITLE
Change OTEL_METRICS_EXPORTER env variable default from none to otlp

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -96,7 +96,7 @@ fi
 # - Set the metrics exporter
 
 if [ -z "${OTEL_METRICS_EXPORTER}" ]; then
-    export OTEL_METRICS_EXPORTER=none;
+    export OTEL_METRICS_EXPORTER=otlp;
 fi
 
 # - Set the service name


### PR DESCRIPTION
Will fix [Issue #475](https://github.com/open-telemetry/opentelemetry-lambda/issues/475) by changing the default value for the OTEL_METRICS_EXPORTER from none to otlp.