### PR TITLE
Set AwsLambdaInstrumentation

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -73,7 +73,7 @@ const instrumentations = [
     suppressInternalInstrumentation: true,
   }),
   new AwsLambdaInstrumentation(typeof configureLambdaInstrumentation === 'function' ? configureLambdaInstrumentation({}) : {}),
-  ...(configureInstrumentations ?? defaultConfigureInstrumentations)()
+  ...(typeof configureInstrumentations === 'function' ? configureInstrumentations: defaultConfigureInstrumentations)()
 ];
 
 // configure lambda logging


### PR DESCRIPTION
### Description 

This pull request updates the instrumentation configuration for AWS Lambda functions. The previous configuration fails the work with `aws-otel-lambda` wrapper [downstream](https://github.com/aws-observability/aws-otel-lambda) and hence fails the [tests](https://github.com/aws-observability/aws-otel-lambda/actions/runs/4208215574/jobs/7303984684#step:28:325).