### PR TITLE
Disable CGO

### DIFF
--- a/go/sample-apps/function/build.sh
+++ b/go/sample-apps/function/build.sh
@@ -4,6 +4,7 @@ set -e
 GOARCH=${GOARCH-amd64}
 
 mkdir -p build
+export CGO_ENABLED=0 
 GOOS=linux go build -o ./build/bootstrap .
 cd build
 zip bootstrap.zip bootstrap

--- a/go/sample-apps/function/build.sh
+++ b/go/sample-apps/function/build.sh
@@ -4,7 +4,6 @@ set -e
 GOARCH=${GOARCH-amd64}
 
 mkdir -p build
-export CGO_ENABLED=0 
-GOOS=linux go build -o ./build/bootstrap .
+CGO_ENABLED=0 GOOS=linux go build -o ./build/bootstrap .
 cd build
 zip bootstrap.zip bootstrap


### PR DESCRIPTION
Update `CGO_ENABLED=0`

This is to avoid the below error message while trying to invoke the `go sample app` using `provided.al2 runtime` in AWS lambda

`/var/task/bootstrap: /lib64/libc.so.6: version GLIBC_2.34' not found (required by /var/task/bootstrap)`

