### PR TITLE
Add support to grpc in the python lambda layer

### DIFF
--- a/python/src/build.sh
+++ b/python/src/build.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+## Valid platform values are "amd64" and "arm64"
+platform=${1:-amd64}
+
 mkdir -p build
-docker build -t aws-otel-lambda-python-layer otel
-docker run --rm -v "$(pwd)/build:/out" aws-otel-lambda-python-layer
+docker buildx build --platform linux/${platform} --build-arg PLATFORM=${platform} --load -t aws-otel-lambda-python-layer  otel
+docker create --name aws-otel-lambda-python-container-${platform} --platform linux/${platform} aws-otel-lambda-python-layer
+docker cp aws-otel-lambda-python-container-${platform}:/build/layer.zip ./build

--- a/python/src/otel/Dockerfile
+++ b/python/src/otel/Dockerfile
@@ -1,11 +1,10 @@
 ARG runtime=python3.9
-
 FROM public.ecr.aws/sam/build-${runtime}
+ARG PLATFORM
 
 ADD . /workspace
 
 WORKDIR /workspace
-
 RUN mkdir -p /build && \
   python3 -m pip install -r otel_sdk/requirements.txt -t /build/python && \
   python3 -m pip install -r otel_sdk/requirements-nodeps.txt -t /build/tmp --no-deps && \
@@ -17,8 +16,12 @@ RUN mkdir -p /build && \
   mv otel_sdk/otel-instrument /build && \
   chmod 755 /build/otel-instrument && \
   rm -rf /build/python/boto* && \
-  rm -rf /build/python/urllib3* && \
-  cd /build && \
-  zip -r layer.zip otel-instrument python
+  rm -rf /build/python/urllib3*
 
-CMD cp /build/layer.zip /out/layer.zip
+WORKDIR /build
+# The pre built grpcio contains a non stripped lib https://github.com/grpc/grpc/issues/29935
+#RUN strip ./python/grpc/_cython/cygrpc.cpython-39-aarch64-linux-gnu.so
+RUN if [ ${PLATFORM} = "arm64" ] ; then \
+     strip ./python/grpc/_cython/cygrpc.cpython-39-aarch64-linux-gnu.so ; \
+  fi
+RUN zip -r layer.zip otel-instrument python

--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -1,3 +1,3 @@
-opentelemetry-exporter-otlp-proto-http==1.16.0
+opentelemetry-exporter-otlp==1.16.0
 opentelemetry-distro==0.37b0
 opentelemetry-instrumentation-aws-lambda==0.37b0


### PR DESCRIPTION
Add support to building lambda layers with grpc in Python.

this is an alternative for solving #534

It will assumes that you have buildx properly installed and configured.

I'm creating this a draft so that we can evaluate this.