### PR TITLE
Release workflow for nodejs layer

### DIFF
--- a/.github/workflows/layer-publish.yml
+++ b/.github/workflows/layer-publish.yml
@@ -53,7 +53,7 @@ jobs:
             LAYER_NAME=$LAYER_NAME-${{ inputs.release-group }}
           fi
           
-          LAYER_VERSION=$(echo "$GITHUB_REF_NAME" | sed -r 's/.*\/[^\d\.]*//g')
+          LAYER_VERSION=$(echo "$GITHUB_REF_NAME" | sed -r 's/.*\/[^0-9\.]*//g')
           LAYER_VERSION_CLEANED=$(echo "$LAYER_VERSION" | sed -r 's/\./_/g')
           
           LAYER_NAME=$LAYER_NAME-$LAYER_VERSION_CLEANED

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -1,0 +1,76 @@
+name: "Release NodeJS Lambda Layer"
+
+on:
+  # (Using tag push instead of release to allow filtering by tag prefix.)
+  push:
+    tags:
+      - layer-nodejs/**
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-layer:
+    runs-on: ubuntu-latest
+    outputs:
+      NODEJS_VERSION: ${{ steps.save-node-sdk-version.outputs.SDK_VERSION}}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Build
+        run: |
+          npm install
+        working-directory: nodejs
+
+      - name: Save Node SDK Version
+        id: save-node-sdk-version
+        run: |
+          SDK_VERSION=$(node version.js)
+          echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_OUTPUT
+        working-directory: nodejs/packages/layer/scripts
+
+      - name: Rename zip file
+        run: mv layer.zip opentelemetry-nodejs-layer.zip
+        working-directory: nodejs/packages/layer/build
+
+      - uses: actions/upload-artifact@v3
+        name: Save assembled layer to build
+        with:
+          name: opentelemetry-nodejs-layer.zip
+          path: nodejs/packages/layer/build/opentelemetry-nodejs-layer.zip
+
+  publish-layer:
+    uses: ./.github/workflows/layer-publish.yml
+    needs: build-layer
+    strategy:
+      matrix:
+        aws_region: 
+#          - ap-northeast-1
+#          - ap-northeast-2
+#          - ap-south-1
+#          - ap-southeast-1
+#          - ap-southeast-2
+#          - ca-central-1
+#          - eu-central-1
+#          - eu-north-1
+#          - eu-west-1
+#          - eu-west-2
+#          - eu-west-3
+#          - sa-east-1
+#          - us-east-1
+#          - us-east-2
+          - us-west-1
+          - us-west-2
+    with:
+      artifact-name: opentelemetry-nodejs-layer.zip
+      layer-name: opentelemetry-nodejs
+      component-version: ${{needs.build-layer.outputs.NODEJS_VERSION}}
+      # architecture:
+      release-group: dev
+      aws_region: ${{ matrix.aws_region }}
+    secrets: inherit

--- a/nodejs/packages/layer/scripts/version.js
+++ b/nodejs/packages/layer/scripts/version.js
@@ -1,0 +1,1 @@
+console.log(require('@opentelemetry/core').VERSION);


### PR DESCRIPTION
This is similar to the existing Java release workflow but for Node.js.

I have also added the `version.js` script in order to get the Javascript SDK version.