### PR TITLE
ensure collector version is produced by amd64

### DIFF
--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -33,6 +33,7 @@ jobs:
           path: ${{ github.workspace }}/collector/build/*.zip
 
       - name: Save Collector Version
+        if: ${{ matrix.architecture == 'amd64' }}
         id: save-collector-version
         shell: bash
         # `./collector -v` output is in the form `otelcol-contrib version 0.75.0`


### PR DESCRIPTION
Otherwise this step fails as the gh runner can't run arm64. We only need this version to be set once anyways.

Fixes #652