### PR TITLE
Prepare nodejs layer release

### DIFF
--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -50,20 +50,20 @@ jobs:
     strategy:
       matrix:
         aws_region: 
-#          - ap-northeast-1
-#          - ap-northeast-2
-#          - ap-south-1
-#          - ap-southeast-1
-#          - ap-southeast-2
-#          - ca-central-1
-#          - eu-central-1
-#          - eu-north-1
-#          - eu-west-1
-#          - eu-west-2
-#          - eu-west-3
-#          - sa-east-1
-#          - us-east-1
-#          - us-east-2
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-south-1
+          - ap-southeast-1
+          - ap-southeast-2
+          - ca-central-1
+          - eu-central-1
+          - eu-north-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - sa-east-1
+          - us-east-1
+          - us-east-2
           - us-west-1
           - us-west-2
     with:
@@ -72,6 +72,6 @@ jobs:
       component-version: ${{needs.build-layer.outputs.NODEJS_VERSION}}
       # architecture:
       runtimes: nodejs14.x nodejs16.x nodejs18.x
-      release-group: dev
+      release-group: prod
       aws_region: ${{ matrix.aws_region }}
     secrets: inherit


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-lambda/pull/737, changed release group to prod and uncommented all regions.