### PR TITLE
Support cross compilation on MacOs M1

### DIFF
--- a/collector/Makefile
+++ b/collector/Makefile
@@ -37,7 +37,7 @@ clean:
 build: clean
 	@echo Building otel collector extension
 	mkdir -p $(BUILD_SPACE)/extensions
-	GOOS=linux $(GOBUILD) $(LDFLAGS) -o $(BUILD_SPACE)/extensions .
+	GOOS=linux GOARCH=$(GOARCH) $(GOBUILD) $(LDFLAGS) -o $(BUILD_SPACE)/extensions .
 
 .PHONY: package
 package: build


### PR DESCRIPTION
This is required in order to get an amd64 on a standard M1 i installation.   
Trying without the proposed changes will result in a `arm64` binary called `*layer*amd64*.zip`