### PR TITLE
Use `exec` to launch python in `otel-instrument` for signal handling.

### DIFF
--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -151,4 +151,4 @@ export _HANDLER="otel_wrapper.lambda_handler";
 
 # - Call the upstream auto instrumentation script
 
-python3 $LAMBDA_LAYER_PKGS_DIR/bin/opentelemetry-instrument "$@"
+exec python3 $LAMBDA_LAYER_PKGS_DIR/bin/opentelemetry-instrument "$@"


### PR DESCRIPTION
Otherwise, we cannot setup signal handlers in python to do things at shutdown.

This now matches how the scripts work for java / node etc:

- https://github.com/open-telemetry/opentelemetry-lambda/blob/b004abbc9af28f9a384f7c0c254abcfe578a2a59/java/layer-wrapper/scripts/otel-handler#L12
- https://github.com/open-telemetry/opentelemetry-lambda/blob/b004abbc9af28f9a384f7c0c254abcfe578a2a59/java/layer-wrapper/scripts/otel-proxy-handler#L12
- https://github.com/open-telemetry/opentelemetry-lambda/blob/b004abbc9af28f9a384f7c0c254abcfe578a2a59/java/layer-wrapper/scripts/otel-sqs-handler#L12
- https://github.com/open-telemetry/opentelemetry-lambda/blob/b004abbc9af28f9a384f7c0c254abcfe578a2a59/java/layer-wrapper/scripts/otel-stream-handler#L12
- https://github.com/open-telemetry/opentelemetry-lambda/blob/b004abbc9af28f9a384f7c0c254abcfe578a2a59/nodejs/packages/layer/scripts/otel-handler#L9