### PR TITLE
Chore: add support to group updates in dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,37 @@ updates:
     directory: "/collector"
     schedule:
       interval: "weekly"
+    groups:
+      opentelemetry-deps-collector:
+        patterns:
+          - "*opentelemetry*"
   - package-ecosystem: "gradle"
     directory: "/java"
     schedule:
       interval: "weekly"
+    groups:
+      opentelemetry-deps-java:
+        patterns:
+          - "io.opentelemetry.*"
   - package-ecosystem: "npm"
     directory: "/nodejs"
     schedule:
       interval: "weekly"
     rebase-strategy: "auto"
+  - package-ecosystem: "npm"
+    directory: "/nodejs/packages/layer"
+    schedule:
+      interval: "weekly"
+    groups:
+      opentelemetry-deps-nodejs:
+        patterns:
+          - "@opentelemetry/*"
+    rebase-strategy: "auto"
   - package-ecosystem: "pip"
     directory: "/python/src/otel/otel_sdk"
     schedule:
       interval: "weekly"
+    groups:
+      opentelemetry-deps-python:
+        patterns:
+          - "opentelemetry-*"


### PR DESCRIPTION
* Add support to [group dependabot PRs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) when updating OpenTelemetry dependencies. 
* Add dependabot entry for nodejs subdirectory `/nodejs/packages/layer` since it is a standalone package. This seems to be the cause for dependabot not create prs for updating opentelemetry dependencies. [reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory).