### PR TITLE
[chore] Update go versions used in workflows

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.7'
+          go-version: '^1.20.8'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.7'
+          go-version: '^1.20.8'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.7'
+          go-version: '^1.20.8'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go for ADOT Collector
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.7'
+          go-version: '^1.20.8'
       - name: Build Python Layer which includes ADOT Collector
         working-directory: python/src
         run: ./run.sh -b

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.7'
+          go-version: '^1.20.8'
       - name: build
         run: make -C collector package GOARCH=${{ matrix.architecture }}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This is a defensive PR to force a minimum go versions in the GHA worfklows. The latest patches contain security fixes. 