### PR TITLE
Update dependabot.yml to include all Otel Python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
           - "@opentelemetry/*"
     rebase-strategy: "auto"
   - package-ecosystem: "pip"
-    directory: "/python/src/otel/otel_sdk"
+    directory: "/python/src/otel"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
In [this PR](https://github.com/open-telemetry/opentelemetry-lambda/pull/908) a new requirement.txt was added that is used only in tox test. We should update that file along this group as well.