### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Some layers include the corresponding OTel language SDK for the Lambda. This all
 
 ## FAQ
 
-* **What exporters/recievers/processors are included from the OpenTelemetry Collector?**
+* **What exporters/receivers/processors are included from the OpenTelemetry Collector?**
     > You can check out [the stripped-down collector's imports](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/lambdacomponents/default.go#L18) in this repository for a full list of currently included components.
 * **Is the Lambda layer provided or do I need to build it and distribute it myself?**
     > This repository does not provide pre-build Lambda layers. They must be built manually and saved in your AWS account. This repo has files to facilitate doing that. More information is provided in [the Collector folder's README](collector/README.md).


### PR DESCRIPTION
Fixed typo
`recievers -> receivers`