### PR TITLE
Move existing approvers to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ Here is a list of community roles with current and previous members:
 
 - Approvers ([@open-telemetry/lambda-extension-approvers](https://github.com/orgs/open-telemetry/teams/lambda-extension-approvers)):
 
-   - [Raphael Philipe Mendes da Silva](https://github.com/rapphil), AWS
    - [Tristan Sloughter](https://github.com/tsloughter), Splunk
-   - [Tyler Benson](https://github.com/tylerbenson), Lightstep
 
 - Emeritus Approvers:
 
@@ -116,6 +114,9 @@ Here is a list of community roles with current and previous members:
    - [Nathaniel Ruiz Nowell](https://github.com/NathanielRN), AWS
 
 - Maintainers ([@open-telemetry/lambda-extension-maintainers](https://github.com/orgs/open-telemetry/teams/lambda-extension-maintainers)):
+
+   - [Tyler Benson](https://github.com/tylerbenson), Lightstep
+   - [Raphael Philipe Mendes da Silva](https://github.com/rapphil), AWS
 
 - Emeritus Maintainers:
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Here is a list of community roles with current and previous members:
 
 - Maintainers ([@open-telemetry/lambda-extension-maintainers](https://github.com/orgs/open-telemetry/teams/lambda-extension-maintainers)):
 
-   - [Tyler Benson](https://github.com/tylerbenson), Lightstep
    - [Raphael Philipe Mendes da Silva](https://github.com/rapphil), AWS
+   - [Tyler Benson](https://github.com/tylerbenson), Lightstep
 
 - Emeritus Maintainers:
 


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/opentelemetry-lambda/pull/967, we discussed on the @open-telemetry/technical-committee and @open-telemetry/governance-committee how we can bootstrap new maintainers for OpenTelemetry Lambda.
We decided to promote @rapphil and @tylerbenson from the current OTel Lambda approvers group to be maintainers.