### PR TITLE
Fix: Use the FQND for the sandbox url

### DIFF
--- a/collector/internal/telemetryapi/listener.go
+++ b/collector/internal/telemetryapi/listener.go
@@ -52,7 +52,7 @@ func listenOnAddress() string {
 	if ok && envAwsLocal == "true" {
 		addr = ":" + defaultListenerPort
 	} else {
-		addr = "sandbox:" + defaultListenerPort
+		addr = "sandbox.localdomain:" + defaultListenerPort
 	}
 
 	return addr

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -227,7 +227,7 @@ func listenOnAddress() string {
 	if ok && envAwsLocal == "true" {
 		addr = ":" + defaultListenerPort
 	} else {
-		addr = "sandbox:" + defaultListenerPort
+		addr = "sandbox.localdomain:" + defaultListenerPort
 	}
 
 	return addr

--- a/collector/receiver/telemetryapireceiver/receiver_test.go
+++ b/collector/receiver/telemetryapireceiver/receiver_test.go
@@ -35,7 +35,7 @@ func TestListenOnAddress(t *testing.T) {
 			desc: "listen on address without AWS_SAM_LOCAL env variable",
 			testFunc: func(t *testing.T) {
 				addr := listenOnAddress()
-				require.EqualValues(t, "sandbox:4325", addr)
+				require.EqualValues(t, "sandbox.localdomain:4325", addr)
 			},
 		},
 		{


### PR DESCRIPTION
Use the FQDN to subscribe and create listeners of the telemetry API so that there is no ambiguity in case the lambda is attached to a VPC with DNS resolution enabled and a name 'sandbox' is resolvable in that VPC.

References: https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api.html