### PR TITLE
Remove dependency on `tidy` task

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: collector
   build:
     runs-on: ubuntu-latest
-    needs: [test, tidy]
+    needs: [test]
     strategy:
       matrix:
         architecture: [ amd64, arm64 ]


### PR DESCRIPTION
This should fix the broken build.  Not sure why the prior PR build didn't catch it.