### PR TITLE
Group generated release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  categories:
+
+    - title: Collector
+      labels:
+        - go
+
+    - title: Python
+      labels:
+        - python
+
+    - title: Javascript
+      labels:
+        - javascript
+
+    - title: Java
+      labels:
+        - java
+
+    - title: Other Dependencies
+      labels:
+        - dependencies
+
+    - title: Other
+      labels:
+        - '*'


### PR DESCRIPTION
Attempt to group generated release notes by label:
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes