### PR TITLE
feat: switch from node 14 to 16

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/cache@v4
         with:
           path: ~/.npm

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -71,7 +71,7 @@ jobs:
       layer-name: opentelemetry-nodejs
       component-version: ${{needs.build-layer.outputs.NODEJS_VERSION}}
       # architecture:
-      runtimes: nodejs14.x nodejs16.x nodejs18.x
+      runtimes: nodejs16.x nodejs18.x nodejs20.x
       release-group: prod
       aws_region: ${{ matrix.aws_region }}
     secrets: inherit

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Build
         run: |

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -6,8 +6,8 @@
   "repository": "open-telemetry/opentelemetry-lambda",
   "scripts": {
     "clean": "rimraf build/*",
-    "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts",
+    "lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts --fix",
     "prepare": "npm run compile",
     "compile": "tsc -p .",
     "postcompile": "copyfiles 'node_modules/**' build/workspace/nodejs && copyfiles -f 'scripts/*' build/workspace && copyfiles -f 'build/src/*' build/workspace && cd build/workspace && bestzip ../layer.zip *"
@@ -23,7 +23,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",

--- a/nodejs/sample-apps/aws-sdk/package.json
+++ b/nodejs/sample-apps/aws-sdk/package.json
@@ -8,8 +8,8 @@
   "repository": "open-telemetry/opentelemetry-lambda",
   "scripts": {
     "clean": "rimraf build/*",
-    "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts",
+    "lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts --fix",
     "precompile": "tsc --version",
     "prepare": "npm run compile",
     "compile": "tsc -p .",
@@ -26,7 +26,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "files": [
     "build/src/**/*.js",
@@ -42,8 +42,6 @@
     "copyfiles": "2.4.1",
     "rimraf": "5.0.5",
     "ts-node": "10.9.2",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "5.3.3"
   },
   "dependencies": {


### PR DESCRIPTION
PR is switching from `node v14` to `node v16` according to [supported runtimes in AWS](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). PR also fixes linter usage.