### PR TITLE
Set default Propagators list and bash script flags

### DIFF
--- a/java/layer-javaagent/scripts/otel-handler
+++ b/java/layer-javaagent/scripts/otel-handler
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 export JAVA_TOOL_OPTIONS="-javaagent:/opt/opentelemetry-javaagent.jar ${JAVA_TOOL_OPTIONS}"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000

--- a/java/layer-wrapper/scripts/otel-handler
+++ b/java/layer-wrapper/scripts/otel-handler
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
 export _HANDLER="io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000

--- a/java/layer-wrapper/scripts/otel-proxy-handler
+++ b/java/layer-wrapper/scripts/otel-proxy-handler
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
 export _HANDLER="io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestApiGatewayWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000

--- a/java/layer-wrapper/scripts/otel-sqs-handler
+++ b/java/layer-wrapper/scripts/otel-sqs-handler
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
 export _HANDLER="io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingSqsEventWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000

--- a/java/layer-wrapper/scripts/otel-stream-handler
+++ b/java/layer-wrapper/scripts/otel-stream-handler
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_HANDLER="$_HANDLER"
 export _HANDLER="io.opentelemetry.instrumentation.awslambdacore.v1_0.TracingRequestStreamWrapper"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 export OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT=10000

--- a/nodejs/packages/layer/scripts/otel-handler
+++ b/nodejs/packages/layer/scripts/otel-handler
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 export NODE_OPTIONS="${NODE_OPTIONS} --require /opt/wrapper.js"
 
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
+fi
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 exec "$@"

--- a/python/sample-apps/run.sh
+++ b/python/sample-apps/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euf -o pipefail
 
 cp -r ../src/otel .
 cp ../src/run.sh layer.sh

--- a/python/src/otel/otel_sdk/otel-instrument
+++ b/python/src/otel/otel_sdk/otel-instrument
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ef -o pipefail
+
 # Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +98,12 @@ fi
 
 if [ -z "${OTEL_SERVICE_NAME}" ]; then
     export OTEL_SERVICE_NAME=$AWS_LAMBDA_FUNCTION_NAME;
+fi
+
+# - Set the propagators
+
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
 fi
 
 # - Set the Resource Detectors (Resource Attributes)

--- a/utils/sam/run.sh
+++ b/utils/sam/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -u
+set -euf -o pipefail
 
 echo_usage() {
 	echo "usage: Deploy Lambda layer/application by SAM"


### PR DESCRIPTION
We want the default propagators to include both w3c context and xray, so set `OTEL_PROPAGATORS=tracecontext,baggage,xray` if it isn't already set to something else.

Users (of tracer layers that have implemented `xray-lambda`) that send traces to X-Ray, especially if they enable Active Tracing, should override this value to `OTEL_PROPAGATORS=tracecontext,baggage,xray-lambda` to ensure proper span relationships within X-Ray.

I also added some common bash flags to align with industry standard practice.