### PR TITLE
Update typescript-eslint version to latest

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -30,8 +30,8 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "7.0.0",
-    "@typescript-eslint/parser": "6.19.1",
+    "@typescript-eslint/eslint-plugin": "^7.7.0",
+    "@typescript-eslint/parser": "^7.7.0",
     "aws-sdk": "2.1594.0",
     "bestzip": "2.2.1",
     "copyfiles": "2.4.1",


### PR DESCRIPTION
This is an attempt to address the dependabot update in https://github.com/open-telemetry/opentelemetry-lambda/pull/1246, which is bumping only one package.