### PR TITLE
Fix: update python unit test to use a valid lambda arn

### DIFF
--- a/python/src/otel/tests/test_otel.py
+++ b/python/src/otel/tests/test_otel.py
@@ -59,7 +59,7 @@ class MockLambdaContext:
 
 MOCK_LAMBDA_CONTEXT = MockLambdaContext(
     aws_request_id="mock_aws_request_id",
-    invoked_function_arn="arn://mock-lambda-function-arn",
+    invoked_function_arn="arn:aws:lambda:us-west-2:123456789012:function:my-function",
 )
 
 MOCK_XRAY_TRACE_ID = 0x5FB7331105E8BB83207FA31D4D9CDB4C


### PR DESCRIPTION
This has to be done because the lambda instrumentation was updated to extract the account id from the arn present in the lambda context in this PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2367

This made the CI in this [dependabot PR](https://github.com/open-telemetry/opentelemetry-lambda/pull/1238) to fail. 

After this pr is merged, the previous dependabot pr should succeed