### PR TITLE
Migrate from `burrunan/gradle-cache-action` to `gradle/actions/setup-gradle`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,6 @@ updates:
       opentelemetry-deps-java:
         patterns:
           - "io.opentelemetry.*"
-      amazon-deps:
-        patterns:
-          - "*amazon*"
       java-other:
         patterns:
           - "*"

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -12,17 +12,27 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: '11'
-      - uses: burrunan/gradle-cache-action@v1.19
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          remote-build-cache-proxy-enabled: false
-          arguments: build --stacktrace
-          build-root-directory: java
+          validate-wrappers: true
+          add-job-summary-as-pr-comment: on-failure # Valid values are 'never' (default), 'always', and 'on-failure'
+
+      - name: Execute Gradle build
+        run: |
+          cd java
+          ./gradlew build --scan --stacktrace

--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -18,17 +18,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK for running Gradle
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: corretto
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v3
-        name: Build Javaagent Layer
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: :layer-javaagent:assemble
-          build-root-directory: java
+          validate-wrappers: true
+
+      - name: Execute Gradle build
+        run: |
+          cd java
+          ./gradlew :layer-javaagent:assemble --scan --stacktrace
 
       - uses: actions/upload-artifact@v4
         name: Save assembled layer to build


### PR DESCRIPTION
Previous action is not really being updated anymore.

Also remove java grouping for amazon dependabot.

https://github.com/burrunan/gradle-cache-action
https://github.com/gradle/actions?tab=readme-ov-file#the-setup-gradle-action