### PR TITLE
Add Stale Issue/PR closer

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -1,0 +1,24 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: "40 3 * * 0" # Run weekly on Sunday at 3:40 AM
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue was marked stale. It will be closed in 30 days without additional activity.'
+          close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still relevant.'
+
+          stale-pr-message: 'This PR was marked stale. It will be closed in 30 days without additional activity.'
+          close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+
+          days-before-stale: 365
+          days-before-close: 30


### PR DESCRIPTION
There are a lot of stale issues and PRs from folks that don't seem involved anymore.  It's possible some are still relevant, so I set a pretty generous grace period: Mark anything older than a year as stale, and close after 30 days of marking as stale.

Seeking feedback on thresholds and verbiage.