### PR TITLE
Add java wrapper layer build

### DIFF
--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -31,13 +31,19 @@ jobs:
       - name: Execute Gradle build
         run: |
           cd java
-          ./gradlew :layer-javaagent:assemble --scan --stacktrace
+          ./gradlew :layer-javaagent:assemble :layer-wrapper:assemble --scan --stacktrace
 
       - uses: actions/upload-artifact@v4
-        name: Save assembled layer to build
+        name: Save javaagent layer to build
         with:
           name: opentelemetry-javaagent-layer.zip
           path: java/layer-javaagent/build/distributions/opentelemetry-javaagent-layer.zip
+
+      - uses: actions/upload-artifact@v4
+        name: Save javawrapper layer to build
+        with:
+          name: opentelemetry-javawrapper-layer.zip
+          path: java/layer-wrapper/build/distributions/opentelemetry-java-wrapper.zip
 
       - name: Save Javaagent Version
         id: save-javaagent-version
@@ -47,7 +53,7 @@ jobs:
           JAVAAGENT_VERSION=$(java -jar ./opentelemetry-javaagent.jar)
           echo "JAVAAGENT_VERSION=$JAVAAGENT_VERSION" >> $GITHUB_OUTPUT
 
-  publish-layer:
+  publish-javaagent-layer:
     uses: ./.github/workflows/layer-publish.yml
     needs: build-layer
     strategy:
@@ -73,6 +79,38 @@ jobs:
       artifact-name: opentelemetry-javaagent-layer.zip
       layer-name: opentelemetry-javaagent
       component-version: ${{needs.build-layer.outputs.JAVAAGENT_VERSION}}
+      # architecture:
+      runtimes: java8 java8.al2 java11 java17
+      release-group: prod
+      aws_region: ${{ matrix.aws_region }}
+    secrets: inherit
+
+  publish-javawrapper-layer:
+    uses: ./.github/workflows/layer-publish.yml
+    needs: build-layer
+    strategy:
+      matrix:
+        aws_region:
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-south-1
+          - ap-southeast-1
+          - ap-southeast-2
+          - ca-central-1
+          - eu-central-1
+          - eu-north-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - sa-east-1
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
+    with:
+      artifact-name: opentelemetry-javawrapper-layer.zip
+      layer-name: opentelemetry-javawrapper
+      component-version: "--"
       # architecture:
       runtimes: java8 java8.al2 java11 java17
       release-group: prod


### PR DESCRIPTION
This approach contains a few arbitrary decisions.
- I chose to tie it to the same release job as java as they will likely always have changes together (sdk version).
- No independent tagging for the wrapper release.
- The underlying reported version for the wrapper layer will report `--`. (Since the wrapper won't have a separate release page, I think this is ok.)