### PR TITLE
Bug fixing: TelemetryAPI receiver

### DIFF
--- a/collector/internal/telemetryapi/client.go
+++ b/collector/internal/telemetryapi/client.go
@@ -27,8 +27,11 @@ import (
 )
 
 const (
+	ApiVersion20220701             = "2022-07-01"
+	ApiVersionLatest               = ApiVersion20220701
 	SchemaVersion20220701          = "2022-07-01"
-	SchemaVersionLatest            = SchemaVersion20220701
+	SchemaVersion20221213          = "2022-12-13"
+	SchemaVersionLatest            = SchemaVersion20221213
 	lambdaAgentIdentifierHeaderKey = "Lambda-Extension-Identifier"
 )
 
@@ -42,7 +45,7 @@ func NewClient(logger *zap.Logger) *Client {
 	return &Client{
 		logger:     logger.Named("telemetryAPI.Client"),
 		httpClient: &http.Client{},
-		baseURL:    fmt.Sprintf("http://%s/%s/telemetry", os.Getenv("AWS_LAMBDA_RUNTIME_API"), SchemaVersionLatest),
+		baseURL:    fmt.Sprintf("http://%s/%s/telemetry", os.Getenv("AWS_LAMBDA_RUNTIME_API"), ApiVersionLatest),
 	}
 }
 

--- a/collector/receiver/telemetryapireceiver/types.go
+++ b/collector/receiver/telemetryapireceiver/types.go
@@ -15,7 +15,7 @@
 package telemetryapireceiver // import "github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver"
 
 type event struct {
-	Time   string         `json:"time"`
-	Type   string         `json:"type"`
-	Record map[string]any `json:"record"`
+	Time   string `json:"time"`
+	Type   string `json:"type"`
+	Record any    `json:"record"`
 }


### PR DESCRIPTION
- Decoupled API version and Schema version
- Updated schema version to "2022-12-13"
- Fixed Record datatype. It should be `any`. Record could be a string in [function](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#telemetry-api-function) type. 