### PR TITLE
Mark auto-instrumentation support for Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The table below captures the state of various features and their levels of suppo
 | - Trace Incoming^<sup>[2]</sup>          |  -   |        |  -   |  +   | N/A  |   -  |
 | - Trace Outgoing^<sup>[3]</sup>          |  +   |        |  -   |  +   | N/A  |   +  |
 | - Metrics^<sup>[4]</sup>                 |  -   |        |  -   |  -   | N/A  |   -  |
-| Auto instrumentation       |      |   +    |  +   |  -   | N/A  |   +  |
+| Auto instrumentation       |  +   |   +    |  +   |  -   | N/A  |   +  |
 | Flush TracerProvider       |  +   |   +    |      |  +   |  +   |   +  |
 | Flush MeterProvider        |  +   |   +    |      |      |      |   -  |
 


### PR DESCRIPTION
At the moment it looks like that the current Node.js wrapper file already does auto-instrumentation (though there is https://github.com/open-telemetry/opentelemetry-lambda/issues/448 is still open which will improve it).

Marking it as supported in this repo is helpful as the ADOT lambda layer does not currently have auto-instrumentation built-in, so it might be useful for people to see that the Node.js lambda layer in this repo does have it out of the box.