### PR TITLE
Add custom build support for lambdacomponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Some layers include the corresponding OTel language SDK for the Lambda. This all
 
 * **What exporters/receivers/processors are included from the OpenTelemetry Collector?**
     > You can check out [the stripped-down collector's imports](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/lambdacomponents/default.go#L18) in this repository for a full list of currently included components.
+  
+    > Self-built binaries of the collector have **experimental** support for a custom set of connectors/exporters/receivers/processors. For more information, see [(Experimental) Customized collector build](#experimental-customized-collector-build)
 * **Is the Lambda layer provided or do I need to build it and distribute it myself?**
     > This repository provides pre-built Lambda layers, their ARNs are available in the [Releases](https://github.com/open-telemetry/opentelemetry-lambda/releases). You can also build the layers manually and publish them in your AWS account. This repo has files to facilitate doing that. More information is provided in [the Collector folder's README](collector/README.md).
 
@@ -98,6 +100,45 @@ The following are runtimes which are no longer or not yet supported by this repo
 [2]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-spans.md#incoming-invocations
 [3]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-spans.md#outgoing-invocations
 [4]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-metrics.md
+
+## (Experimental) Customized collector build
+The collector can be built with a customized set of connectors/exporters/receivers/processors. This feature is **experimental** and is only supported for self-built binaries of the collector.
+
+### Build Tags
+The build-tag `lambdacomponents.custom` must always be provided to opt-in for a custom build.
+Once this build-tag is present, you need provide additional build-tags to include your desired components in the resulting binary:
+
+- `lambdacomponents.all` includes all available components
+- `lambdacomponents.connector.all` includes all available connectors
+- `lambdacomponents.exporter.all` includes all available exporters
+- `lambdacomponents.extension.all` includes all available extensions
+- `lambdacomponents.processor.all` includes all available processors
+- `lambdacomponents.receiver.all` includes all available receivers
+
+Each available component can also be included explicitly by using its specific build-tag. For a full-list of available components, have a look into the [lambdacomponents](./collector/lambdacomponents) package.
+
+As an example, the full build command including the following components:
+- All receivers
+- All processors
+- No extensions
+- Only the otlphttp exporter
+- Only the spanmetrics connector
+
+would be the following:
+```shell
+go build -tags "lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomponents.processor.all,lambdacomponents.exporter.otlphttp,lambdacomponents.connector.spanmetrics"
+```
+
+### Adding additional options
+To add more options for a customized build, you can add your desired component to the [lambdacomponents](./collector/lambdacomponents) package.
+Make sure to always restrict your addition using the appropriate build-tags.
+
+For example, if you want to add the extension `foo`, the file providing this extension should be located in the [extension](./collector/lambdacomponents/extension) directory have to following build restriction:
+```
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.extension.all || lambdacomponents.extension.foo)
+```
+
+You can provide your addition as a pull-request to this repository. Before doing so, please also read through the details of [Contributing](#contributing) to this project.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ go build -tags "lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomp
 To add more options for a customized build, you can add your desired component to the [lambdacomponents](./collector/lambdacomponents) package.
 Make sure to always restrict your addition using the appropriate build-tags.
 
-For example, if you want to add the extension `foo`, the file providing this extension should be located in the [extension](./collector/lambdacomponents/extension) directory have to following build restriction:
+For example, if you want to add the extension `foo`, the file providing this extension should be located in the [extension](./collector/lambdacomponents/extension) directory have the following build restriction:
 ```
 //go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.extension.all || lambdacomponents.extension.foo)
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Some layers include the corresponding OTel language SDK for the Lambda. This all
 * **What exporters/receivers/processors are included from the OpenTelemetry Collector?**
     > You can check out [the stripped-down collector's imports](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/lambdacomponents/default.go#L18) in this repository for a full list of currently included components.
   
-    > Self-built binaries of the collector have **experimental** support for a custom set of connectors/exporters/receivers/processors. For more information, see [(Experimental) Customized collector build](#experimental-customized-collector-build)
+    > Self-built binaries of the collector have **experimental** support for a custom set of connectors/exporters/receivers/processors. For more information, see [(Experimental) Customized collector build](./collector/README.md#experimental-customized-collector-build)
 * **Is the Lambda layer provided or do I need to build it and distribute it myself?**
     > This repository provides pre-built Lambda layers, their ARNs are available in the [Releases](https://github.com/open-telemetry/opentelemetry-lambda/releases). You can also build the layers manually and publish them in your AWS account. This repo has files to facilitate doing that. More information is provided in [the Collector folder's README](collector/README.md).
 
@@ -100,45 +100,6 @@ The following are runtimes which are no longer or not yet supported by this repo
 [2]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-spans.md#incoming-invocations
 [3]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-spans.md#outgoing-invocations
 [4]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/faas-metrics.md
-
-## (Experimental) Customized collector build
-The collector can be built with a customized set of connectors/exporters/receivers/processors. This feature is **experimental** and is only supported for self-built binaries of the collector.
-
-### Build Tags
-The build-tag `lambdacomponents.custom` must always be provided to opt-in for a custom build.
-Once this build-tag is present, you need provide additional build-tags to include your desired components in the resulting binary:
-
-- `lambdacomponents.all` includes all available components
-- `lambdacomponents.connector.all` includes all available connectors
-- `lambdacomponents.exporter.all` includes all available exporters
-- `lambdacomponents.extension.all` includes all available extensions
-- `lambdacomponents.processor.all` includes all available processors
-- `lambdacomponents.receiver.all` includes all available receivers
-
-Each available component can also be included explicitly by using its specific build-tag. For a full-list of available components, have a look into the [lambdacomponents](./collector/lambdacomponents) package.
-
-As an example, the full build command including the following components:
-- All receivers
-- All processors
-- No extensions
-- Only the otlphttp exporter
-- Only the spanmetrics connector
-
-would be the following:
-```shell
-go build -tags "lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomponents.processor.all,lambdacomponents.exporter.otlphttp,lambdacomponents.connector.spanmetrics"
-```
-
-### Adding additional options
-To add more options for a customized build, you can add your desired component to the [lambdacomponents](./collector/lambdacomponents) package.
-Make sure to always restrict your addition using the appropriate build-tags.
-
-For example, if you want to add the extension `foo`, the file providing this extension should be located in the [extension](./collector/lambdacomponents/extension) directory have the following build restriction:
-```
-//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.extension.all || lambdacomponents.extension.foo)
-```
-
-You can provide your addition as a pull-request to this repository. Before doing so, please also read through the details of [Contributing](#contributing) to this project.
 
 ## Contributing
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -7,7 +7,7 @@ LAYER_NAME:=otel-collector
 OTELCOL_VERSION="UNSET" # run recipe set-otelcol-version to get this
 GIT_SHA=$(shell git rev-parse HEAD)
 GOARCH ?= amd64
-GOBUILD=GO111MODULE=on CGO_ENABLED=0 installsuffix=cgo go build -trimpath
+GOBUILD=GO111MODULE=on CGO_ENABLED=0 installsuffix=cgo go build -trimpath$(if ${BUILDTAGS}, -tags "${BUILDTAGS}",)
 BUILD_INFO_IMPORT_PATH=main
 
 LDFLAGS=-ldflags "-s -w -X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA) -X $(BUILD_INFO_IMPORT_PATH).Version=$(OTELCOL_VERSION) \

--- a/collector/README.md
+++ b/collector/README.md
@@ -29,7 +29,7 @@ Once this build-tag is present, you need provide additional build-tags to includ
 
 Each available component can also be included explicitly by using its specific build-tag. For a full-list of available components, have a look into the [lambdacomponents](./collector/lambdacomponents) package.
 
-As an example, the full build command including the following components:
+As an example, the full command to publish OpenTelemetry Collector Lambda layer in your AWS account and get its ARN including the following components:
 - All receivers
 - All processors
 - No extensions
@@ -38,7 +38,7 @@ As an example, the full build command including the following components:
 
 would be the following:
 ```shell
-go build -tags "lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomponents.processor.all,lambdacomponents.exporter.otlphttp,lambdacomponents.connector.spanmetrics"
+cd collector && BUILDTAGS="lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomponents.processor.all,lambdacomponents.exporter.otlphttp,lambdacomponents.connector.spanmetrics" make publish-layer
 ```
 
 ### Adding additional options

--- a/collector/README.md
+++ b/collector/README.md
@@ -13,6 +13,45 @@ Be sure to:
 * Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 * Config [AWS credential](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 
+## (Experimental) Customized collector build
+The collector can be built with a customized set of connectors/exporters/receivers/processors. This feature is **experimental** and is only supported for self-built binaries of the collector.
+
+### Build Tags
+The build-tag `lambdacomponents.custom` must always be provided to opt-in for a custom build.
+Once this build-tag is present, you need provide additional build-tags to include your desired components in the resulting binary:
+
+- `lambdacomponents.all` includes all available components
+- `lambdacomponents.connector.all` includes all available connectors
+- `lambdacomponents.exporter.all` includes all available exporters
+- `lambdacomponents.extension.all` includes all available extensions
+- `lambdacomponents.processor.all` includes all available processors
+- `lambdacomponents.receiver.all` includes all available receivers
+
+Each available component can also be included explicitly by using its specific build-tag. For a full-list of available components, have a look into the [lambdacomponents](./collector/lambdacomponents) package.
+
+As an example, the full build command including the following components:
+- All receivers
+- All processors
+- No extensions
+- Only the otlphttp exporter
+- Only the spanmetrics connector
+
+would be the following:
+```shell
+go build -tags "lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomponents.processor.all,lambdacomponents.exporter.otlphttp,lambdacomponents.connector.spanmetrics"
+```
+
+### Adding additional options
+To add more options for a customized build, you can add your desired component to the [lambdacomponents](./collector/lambdacomponents) package.
+Make sure to always restrict your addition using the appropriate build-tags.
+
+For example, if you want to add the extension `foo`, the file providing this extension should be located in the [extension](./collector/lambdacomponents/extension) directory have the following build restriction:
+```
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.extension.all || lambdacomponents.extension.foo)
+```
+
+You can provide your addition as a pull-request to this repository. Before doing so, please also read through the details of [Contributing](#contributing) to this project.
+
 ## Installing
 To install the OpenTelemetry Collector Lambda layer to an existing Lambda function using the `aws` CLI:
 

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -79,14 +79,17 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/knadh/koanf/v2 v2.1.1 // indirect
+	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -95,6 +98,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.107.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.107.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.107.0 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -90,6 +90,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -98,6 +100,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -114,6 +118,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lightstep/go-expohisto v1.0.0 h1:UPtTS1rGdtehbbAF7o/dhkWLTDI73UifG8LbfQI7cA4=
+github.com/lightstep/go-expohisto v1.0.0/go.mod h1:xDXD0++Mu2FOaItXtdDfksfgxfV0z1TMPa+e/EUd0cs=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
@@ -135,6 +141,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3pro
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.107.0/go.mod h1:BIZvmh0Jx3qxmmUpQs4Wmp+yw3eZTinKBd1uRAdDRPg=
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider v0.107.0 h1:XZGFxuM2NpjCDPKi/zrVXAaf+JN6Rlp/HlkI9lg+jc4=
 github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider v0.107.0/go.mod h1:Fo7KPO1ElNawOHDL4peoRgU3V+DmoRF65R2i7Ox1I/c=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0 h1:1S+oa3bMVrSi7PclgMvxtyPAi8mTdHsuDqAq8XA06qU=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0/go.mod h1:jrqMHeaEBFtmRKKocfoVrfGjRYWp2+nj9C2aGdEN7xo=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.107.0 h1:okRANT1e80Lva/ck1gWZXF4Z1caH4SIz5A4crYPfylw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.107.0/go.mod h1:GJoWZ9tTTev7+HjiXW0uV61tYDGTorNmy1Wdg7UmaQU=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.107.0 h1:Xt9yRUYN3vyzjgc3rRwQ10OZ+WTnrIsergAdrEF7usQ=

--- a/collector/lambdacomponents/connector/pkg.go
+++ b/collector/lambdacomponents/connector/pkg.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import "go.opentelemetry.io/collector/connector"
+
+var Factories []func(extensionId string) connector.Factory

--- a/collector/lambdacomponents/connector/spanmetrics.go
+++ b/collector/lambdacomponents/connector/spanmetrics.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.connector.all || lambdacomponents.connector.spanmetrics)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
+	"go.opentelemetry.io/collector/connector"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) connector.Factory {
+		return spanmetricsconnector.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/custom.go
+++ b/collector/lambdacomponents/custom.go
@@ -1,0 +1,83 @@
+//go:build lambdacomponents.custom
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambdacomponents
+
+import (
+	custom_connector "github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents/connector"
+	custom_exporter "github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents/exporter"
+	custom_extension "github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents/extension"
+	custom_processor "github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents/processor"
+	custom_receiver "github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents/receiver"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/otelcol"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/receiver"
+
+	"go.uber.org/multierr"
+)
+
+func Components(extensionID string) (otelcol.Factories, error) {
+	var errs []error
+
+	receivers, err := makeFactoryMap(custom_receiver.Factories, receiver.MakeFactoryMap, extensionID)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	processors, err := makeFactoryMap(custom_processor.Factories, processor.MakeFactoryMap, extensionID)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	exporters, err := makeFactoryMap(custom_exporter.Factories, exporter.MakeFactoryMap, extensionID)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	extensions, err := makeFactoryMap(custom_extension.Factories, extension.MakeFactoryMap, extensionID)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	connectors, err := makeFactoryMap(custom_connector.Factories, connector.MakeFactoryMap, extensionID)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	factories := otelcol.Factories{
+		Receivers:  receivers,
+		Processors: processors,
+		Exporters:  exporters,
+		Extensions: extensions,
+		Connectors: connectors,
+	}
+
+	return factories, multierr.Combine(errs...)
+}
+
+func makeFactoryMap[F any](factories []func(extensionId string) F, fn func(...F) (map[component.Type]F, error), extensionId string) (map[component.Type]F, error) {
+	preprocessedFactories := make([]F, len(factories))
+	for i, f := range factories {
+		preprocessedFactories[i] = f(extensionId)
+	}
+
+	return fn(preprocessedFactories...)
+}

--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -1,3 +1,5 @@
+//go:build !lambdacomponents.custom
+
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/collector/lambdacomponents/exporter/logging.go
+++ b/collector/lambdacomponents/exporter/logging.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.exporter.all || lambdacomponents.exporter.logging)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/loggingexporter"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) exporter.Factory {
+		return loggingexporter.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/exporter/otlp.go
+++ b/collector/lambdacomponents/exporter/otlp.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.exporter.all || lambdacomponents.exporter.otlp)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) exporter.Factory {
+		return otlpexporter.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/exporter/otlphttp.go
+++ b/collector/lambdacomponents/exporter/otlphttp.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.exporter.all || lambdacomponents.exporter.otlphttp)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) exporter.Factory {
+		return otlphttpexporter.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/exporter/pkg.go
+++ b/collector/lambdacomponents/exporter/pkg.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import "go.opentelemetry.io/collector/exporter"
+
+var Factories  []func(extensionId string) exporter.Factory

--- a/collector/lambdacomponents/exporter/prometheusremotewrite.go
+++ b/collector/lambdacomponents/exporter/prometheusremotewrite.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.exporter.all || lambdacomponents.exporter.prometheusremotewrite)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
+	"go.opentelemetry.io/collector/exporter"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) exporter.Factory {
+		return prometheusremotewriteexporter.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/extension/pkg.go
+++ b/collector/lambdacomponents/extension/pkg.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extension
+
+import "go.opentelemetry.io/collector/extension"
+
+var Factories []func(extensionId string) extension.Factory

--- a/collector/lambdacomponents/extension/sigv4auth.go
+++ b/collector/lambdacomponents/extension/sigv4auth.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.extension.all || lambdacomponents.extension.sigv4auth)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extension
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
+	"go.opentelemetry.io/collector/extension"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) extension.Factory {
+		return sigv4authextension.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -5,6 +5,7 @@ go 1.21.0
 toolchain go1.22.2
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.107.0
@@ -15,6 +16,8 @@ require (
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.98.0
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.98.0
+	go.opentelemetry.io/collector/component v0.107.0
+	go.opentelemetry.io/collector/connector v0.107.0
 	go.opentelemetry.io/collector/exporter v0.107.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.107.0
@@ -62,14 +65,17 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/knadh/koanf/v2 v2.1.1 // indirect
+	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -109,7 +115,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.107.0 // indirect
 	go.opentelemetry.io/collector/client v1.13.0 // indirect
-	go.opentelemetry.io/collector/component v0.107.0 // indirect
 	go.opentelemetry.io/collector/component/componentprofiles v0.107.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.107.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.13.0 // indirect
@@ -122,7 +127,6 @@ require (
 	go.opentelemetry.io/collector/config/configtls v1.13.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.107.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.107.0 // indirect
-	go.opentelemetry.io/collector/connector v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.107.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.107.0 // indirect

--- a/collector/lambdacomponents/go.sum
+++ b/collector/lambdacomponents/go.sum
@@ -78,6 +78,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -86,6 +88,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -102,6 +106,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lightstep/go-expohisto v1.0.0 h1:UPtTS1rGdtehbbAF7o/dhkWLTDI73UifG8LbfQI7cA4=
+github.com/lightstep/go-expohisto v1.0.0/go.mod h1:xDXD0++Mu2FOaItXtdDfksfgxfV0z1TMPa+e/EUd0cs=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
@@ -119,6 +125,8 @@ github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mL
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0 h1:1S+oa3bMVrSi7PclgMvxtyPAi8mTdHsuDqAq8XA06qU=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0/go.mod h1:jrqMHeaEBFtmRKKocfoVrfGjRYWp2+nj9C2aGdEN7xo=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.107.0 h1:okRANT1e80Lva/ck1gWZXF4Z1caH4SIz5A4crYPfylw=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.107.0/go.mod h1:GJoWZ9tTTev7+HjiXW0uV61tYDGTorNmy1Wdg7UmaQU=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.107.0 h1:Xt9yRUYN3vyzjgc3rRwQ10OZ+WTnrIsergAdrEF7usQ=

--- a/collector/lambdacomponents/processor/attributes.go
+++ b/collector/lambdacomponents/processor/attributes.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.attributes)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return attributesprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/batch.go
+++ b/collector/lambdacomponents/processor/batch.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.batch)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return batchprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/coldstart.go
+++ b/collector/lambdacomponents/processor/coldstart.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.coldstart)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return coldstartprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/decouple.go
+++ b/collector/lambdacomponents/processor/decouple.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.decouple)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return decoupleprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/filter.go
+++ b/collector/lambdacomponents/processor/filter.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.filter)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return filterprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/memorylimiter.go
+++ b/collector/lambdacomponents/processor/memorylimiter.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.memorylimiter)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return memorylimiterprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/pkg.go
+++ b/collector/lambdacomponents/processor/pkg.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import "go.opentelemetry.io/collector/processor"
+
+var Factories []func(extensionId string) processor.Factory

--- a/collector/lambdacomponents/processor/probabilisticsampler.go
+++ b/collector/lambdacomponents/processor/probabilisticsampler.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.probabilisticsampler)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return probabilisticsamplerprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/resource.go
+++ b/collector/lambdacomponents/processor/resource.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.resource)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return resourceprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/processor/span.go
+++ b/collector/lambdacomponents/processor/span.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.processor.all || lambdacomponents.processor.span)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
+	"go.opentelemetry.io/collector/processor"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) processor.Factory {
+		return spanprocessor.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/receiver/otlp.go
+++ b/collector/lambdacomponents/receiver/otlp.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.receiver.all || lambdacomponents.receiver.otlp)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiver
+
+import (
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) receiver.Factory {
+		return otlpreceiver.NewFactory()
+	})
+}

--- a/collector/lambdacomponents/receiver/pkg.go
+++ b/collector/lambdacomponents/receiver/pkg.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiver
+
+import "go.opentelemetry.io/collector/receiver"
+
+var Factories  []func(extensionId string) receiver.Factory

--- a/collector/lambdacomponents/receiver/telemetryapi.go
+++ b/collector/lambdacomponents/receiver/telemetryapi.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.receiver.all || lambdacomponents.receiver.telemetryapi)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiver
+
+import (
+	"github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) receiver.Factory {
+		return telemetryapireceiver.NewFactory(extensionId)
+	})
+}


### PR DESCRIPTION
Adding support for customized builds of the collector.

## Motivation
I hoped to use the `spanmetricsconnector` using this collector, but sadly found it not to be part of this distribution.

I also tried doing so in a customized fork, but found it to be extremely cumbersome to do with how go handles `internal`-packages together with forks. With how the project is structured, I saw myself adding a lot of `replace` instructions to the different `go.mod` files to make a successful build of my fork.

I came to the conclusion that others might also want to use more specialized versions for their usecases and figured out this could be done without affecting the distribution for everyone else by making use of build tags.

## Alternatives Considered
### Customized fork of this repository
As mentioned above, I initially considered forking this repository and adding my desired components to my fork.
However, I faced issues building from the fork because of how go handles the `internal`-Package. I was able to solve the issues I was facing, but only by adding a lot of `replace` instructions to several `go.mod` files.

This might be just due to my limited knowledge of go's build system.

### Customized collector, utilizing this repositories collector as a library
Similar to https://medium.com/opentelemetry/building-your-own-opentelemetry-collector-distribution-42337e994b63

I tried building my own collector layer, utilizing the lambda-lifecycle of this project to integrate the resulting collector with AWS Lambdas extension API.

Trying to import the following packages:
```golang
import (
	"github.com/open-telemetry/opentelemetry-lambda/collector/internal/lifecycle"
	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle"
)
```

Results in the following error on a fresh go project:
```
go: github.com/gw2auth/custom-opentelemetry-lambda-collector imports
	github.com/open-telemetry/opentelemetry-lambda/collector/internal/lifecycle imports
	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents: reading github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents/go.mod at revision collector/lambdacomponents/v0.98.0: unknown revision collector/lambdacomponents/v0.98.0
```

It seems not as easy to do this as I initially thought it would be.

Again, this might be just due to my limited knowledge of go's build system.

### [OCB](https://opentelemetry.io/docs/collector/custom-collector/)
OCB works great for using a customized set of components not yet covered in any of the existing distributions or even adding fully custom componnents. However, this results in a "standard" collector which doesn't include the AWS Lambda extension API communication.

### Conclusion
I checked previous PRs and Issues of this project and found that the usual approach was to add components (https://github.com/open-telemetry/opentelemetry-lambda/issues/102 , https://github.com/open-telemetry/opentelemetry-lambda/issues/1196) as long as these additional components are expected to be useful for a reasonable number of users of this specialized collector.

However, this approach does not work well for more niche components, which might only be useful for few usecases.

This PR adds an in-between method to include components, without inflating the collector binary with components which would only be useful for a minority.
Additionally, this PR enables everyone to reduce their self-built collector to only the set of components they actually need, potentially reducing the size of the resulting binary compared to the default set of components.

## Usage
If the collector is built without build tags, the `default.go` Components will be used.

If the collector is built with `lambdacomponents.custom`, the `custom.go` Components will be used.
This allows a customized set of components to be included, for example:

```shell
go build -tags "lambdacomponents.custom,lambdacomponents.receiver.all,lambdacomponents.processor.all,lambdacomponents.exporter.otlphttp,lambdacomponents.connector.spanmetrics"
```

This would include:
- All receivers
- All processors
- No extensions
- Only the otlphttp exporter
- Only the spanmetrics connector
