### PR TITLE
log the name of the state

### DIFF
--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -126,7 +126,7 @@ func (c *Collector) Start(ctx context.Context) error {
 		case otelcol.StateRunning:
 			return nil
 		default:
-			err = fmt.Errorf("unable to start, otelcol state is %d", state)
+			err = fmt.Errorf("unable to start, otelcol state is %s", state.String())
 		}
 	}
 }


### PR DESCRIPTION
The int value of the state is not super helpful to end users. Logging the name of the state instead.