### PR TITLE
Fix wrapper publish step

### DIFF
--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -108,7 +108,7 @@ jobs:
           - us-west-1
           - us-west-2
     with:
-      artifact-name: opentelemetry-javawrapper-layer.zip
+      artifact-name: opentelemetry-java-wrapper.zip
       layer-name: opentelemetry-javawrapper
       component-version: "--"
       # architecture:


### PR DESCRIPTION
When I originally added it, I used the wrong file name so build was failing with `Error parsing parameter '--zip-file': Unable to load paramfile fileb://opentelemetry-javawrapper-layer.zip: [Errno 2] No such file or directory: 'opentelemetry-javawrapper-layer.zip'`