### PR TITLE
feat(nodejs): add propagator auto-configuration

### DIFF
--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -28,8 +28,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",
+    "@opentelemetry/auto-configuration-propagators": "^0.2.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.52.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.52.1",
     "@opentelemetry/instrumentation": "^0.52.1",
     "@opentelemetry/instrumentation-aws-lambda": "^0.43.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.43.0",

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -23,6 +23,7 @@ import { getEnv } from '@opentelemetry/core';
 import { AwsLambdaInstrumentationConfig } from '@opentelemetry/instrumentation-aws-lambda';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { MeterProvider, MeterProviderOptions } from '@opentelemetry/sdk-metrics';
+import { getPropagator } from '@opentelemetry/auto-configuration-propagators';
 
 function defaultConfigureInstrumentations() {
   // Use require statements for instrumentation to avoid having to have transitive dependencies on all the typescript
@@ -120,6 +121,10 @@ async function initializeProvider() {
   let sdkRegistrationConfig: SDKRegistrationConfig = {};
   if (typeof configureSdkRegistration === 'function') {
     sdkRegistrationConfig = configureSdkRegistration(sdkRegistrationConfig);
+  }
+  // auto-configure propagator if not provided
+  if (!sdkRegistrationConfig.propagator) {
+    sdkRegistrationConfig.propagator = getPropagator();
   }
   tracerProvider.register(sdkRegistrationConfig);
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-js/issues/4494

In order to support configuring the `xray` and `xray-lambda` propagators using the OTEL_PROPAGATORS environment variable, the [auto-configuration-propagators](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-configuration-propagators) package must be used.

This change adds this auto-configuration to the layer. When propagator is not explicitly configured, then it will be automatically determined based on the env variable using this auto-configuration module.
