### PR TITLE
Install all transitive dependencies for Python instrumentation

### DIFF
--- a/python/src/otel/otel_sdk/nodeps-requirements.txt
+++ b/python/src/otel/otel_sdk/nodeps-requirements.txt
@@ -1,31 +1,4 @@
-opentelemetry-instrumentation-aiohttp-client==0.47b0
-opentelemetry-util-http==0.47b0
-asgiref~=3.8
-opentelemetry-instrumentation-asgi==0.47b0
-opentelemetry-instrumentation-asyncpg==0.47b0
-opentelemetry-instrumentation-boto==0.47b0
-opentelemetry-instrumentation-boto3sqs==0.47b0
-opentelemetry-instrumentation-botocore==0.47b0
-opentelemetry-instrumentation-celery==0.47b0
-opentelemetry-instrumentation-dbapi==0.47b0
-opentelemetry-instrumentation-django==0.47b0
-opentelemetry-instrumentation-elasticsearch==0.47b0
-opentelemetry-instrumentation-fastapi==0.47b0
-opentelemetry-instrumentation-falcon==0.47b0
-opentelemetry-instrumentation-flask==0.47b0
-opentelemetry-instrumentation-grpc==0.47b0
-opentelemetry-instrumentation-jinja2==0.47b0
-opentelemetry-instrumentation-mysql==0.47b0
-opentelemetry-instrumentation-psycopg2==0.47b0
-opentelemetry-instrumentation-pymemcache==0.47b0
-opentelemetry-instrumentation-pymongo==0.47b0
-opentelemetry-instrumentation-pymysql==0.47b0
-opentelemetry-instrumentation-pyramid==0.47b0
-opentelemetry-instrumentation-redis==0.47b0
-opentelemetry-instrumentation-requests==0.47b0
-opentelemetry-instrumentation-sqlalchemy==0.47b0
-opentelemetry-instrumentation-sqlite3==0.47b0
-opentelemetry-instrumentation-starlette==0.47b0
-opentelemetry-instrumentation-tornado==0.47b0
-opentelemetry-instrumentation-wsgi==0.47b0
+# TODO: move this dependency to requirements.txt when this dependency gets updated to 0.48b0
+# This has to be done because 0.47b0 is pinning a specific version of opentelemetry-propagator-aws-xray
+# causing dependency resolution conflicts.
 opentelemetry-instrumentation-aws-lambda==0.47b0

--- a/python/src/otel/otel_sdk/nodeps-requirements.txt
+++ b/python/src/otel/otel_sdk/nodeps-requirements.txt
@@ -1,4 +1,4 @@
-# TODO: move this dependency to requirements.txt when this dependency gets updated to 0.48b0
-# This has to be done because 0.47b0 is pinning a specific version of opentelemetry-propagator-aws-xray
-# causing dependency resolution conflicts.
+# TODO: move these dependencies to requirements.txt when they stopped relying on a pinned version of
+# opentelemetry-propagator-aws-xray
 opentelemetry-instrumentation-aws-lambda==0.47b0
+opentelemetry-instrumentation-botocore==0.47b0

--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -12,7 +12,6 @@ opentelemetry-instrumentation-asgi==0.47b0
 opentelemetry-instrumentation-asyncpg==0.47b0
 opentelemetry-instrumentation-boto==0.47b0
 opentelemetry-instrumentation-boto3sqs==0.47b0
-opentelemetry-instrumentation-botocore==0.47b0
 opentelemetry-instrumentation-celery==0.47b0
 opentelemetry-instrumentation-dbapi==0.47b0
 opentelemetry-instrumentation-django==0.47b0

--- a/python/src/otel/otel_sdk/requirements.txt
+++ b/python/src/otel/otel_sdk/requirements.txt
@@ -2,5 +2,36 @@ opentelemetry-sdk==1.26.0
 opentelemetry-exporter-otlp-proto-http==1.26.0
 opentelemetry-distro==0.47b0
 opentelemetry-instrumentation==0.47b0
-opentelemetry-semantic-conventions == 0.47b0
+opentelemetry-semantic-conventions==0.47b0
 opentelemetry-propagator-aws-xray==1.0.2
+
+# Instrumentation dependencies
+opentelemetry-instrumentation-aiohttp-client==0.47b0
+opentelemetry-util-http==0.47b0
+opentelemetry-instrumentation-asgi==0.47b0
+opentelemetry-instrumentation-asyncpg==0.47b0
+opentelemetry-instrumentation-boto==0.47b0
+opentelemetry-instrumentation-boto3sqs==0.47b0
+opentelemetry-instrumentation-botocore==0.47b0
+opentelemetry-instrumentation-celery==0.47b0
+opentelemetry-instrumentation-dbapi==0.47b0
+opentelemetry-instrumentation-django==0.47b0
+opentelemetry-instrumentation-elasticsearch==0.47b0
+opentelemetry-instrumentation-fastapi==0.47b0
+opentelemetry-instrumentation-falcon==0.47b0
+opentelemetry-instrumentation-flask==0.47b0
+opentelemetry-instrumentation-grpc==0.47b0
+opentelemetry-instrumentation-jinja2==0.47b0
+opentelemetry-instrumentation-mysql==0.47b0
+opentelemetry-instrumentation-psycopg2==0.47b0
+opentelemetry-instrumentation-pymemcache==0.47b0
+opentelemetry-instrumentation-pymongo==0.47b0
+opentelemetry-instrumentation-pymysql==0.47b0
+opentelemetry-instrumentation-pyramid==0.47b0
+opentelemetry-instrumentation-redis==0.47b0
+opentelemetry-instrumentation-requests==0.47b0
+opentelemetry-instrumentation-sqlalchemy==0.47b0
+opentelemetry-instrumentation-sqlite3==0.47b0
+opentelemetry-instrumentation-starlette==0.47b0
+opentelemetry-instrumentation-tornado==0.47b0
+opentelemetry-instrumentation-wsgi==0.47b0


### PR DESCRIPTION
Fixes: #1482

This change will install all Python transitive dependencies of the instrumentation supported by the lambda layer. This has to be done to reduce the friction for users, so that they are not required to install extra dependencies for their instrumentation to work.

There are some exceptions that will be handled separately because they are depending on a pinned version of opentelemetry-propagator-aws-xray. We wont need to keep those exceptions in the next release because it is already fixed https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2773