### PR TITLE
Fix release workflow for java wrapper

### DIFF
--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       JAVAAGENT_VERSION: ${{ steps.save-javaagent-version.outputs.JAVAAGENT_VERSION }}
+      JAVAWRAPPER_VERSION: ${{ steps.save-javawrapper-version.outputs.JAVAWRAPPER_VERSION }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,6 +51,14 @@ jobs:
           unzip java/layer-javaagent/build/distributions/opentelemetry-javaagent-layer.zip
           JAVAAGENT_VERSION=$(java -jar ./opentelemetry-javaagent.jar)
           echo "JAVAAGENT_VERSION=$JAVAAGENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Save Java Wrapper Version
+        id: save-javawrapper-version
+        shell: bash
+        run: |
+          cd java
+          JAVAWRAPPER_VERSION=$(./gradlew layer-wrapper:printOtelJavaInstrumentationVersion -q)
+          echo "JAVAWRAPPER_VERSION=$JAVAWRAPPER_VERSION" >> $GITHUB_OUTPUT
 
   publish-javaagent-layer:
     uses: ./.github/workflows/layer-publish.yml
@@ -108,7 +117,7 @@ jobs:
     with:
       artifact-name: opentelemetry-javawrapper-layer.zip
       layer-name: opentelemetry-javawrapper
-      component-version: "--"
+      component-version: ${{needs.build-layer.outputs.JAVAWRAPPER_VERSION}}
       # architecture:
       runtimes: java8.al2 java11 java17
       release-group: prod

--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -106,7 +106,7 @@ jobs:
           - us-west-1
           - us-west-2
     with:
-      artifact-name: opentelemetry-java-wrapper.zip
+      artifact-name: opentelemetry-javawrapper-layer.zip
       layer-name: opentelemetry-javawrapper
       component-version: "--"
       # architecture:

--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -34,3 +34,9 @@ tasks {
         dependsOn(createLayer)
     }
 }
+
+tasks.register("printOtelJavaInstrumentationVersion") {
+    doLast {
+        println(project.configurations["runtimeClasspath"].resolvedConfiguration.resolvedArtifacts.find {  it.name == "opentelemetry-aws-lambda-events-2.2" }?.moduleVersion?.id?.version)
+    }
+}


### PR DESCRIPTION
When I tried to run the release, I was getting the following error: https://github.com/open-telemetry/opentelemetry-lambda/actions/runs/10497486130/job/29080482132#step:3:13

I'm also adding a gradle task `printOtelJavaInstrumentationVersion` to print th eversion of the otel java instrumentation that is being used in the java wrapper layer. Example output:
```
./gradlew layer-wrapper:printOtelJavaInstrumentationVersion -q
2.7.0-alpha
```