### PR TITLE
Fix Dependabot for Ruby

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,7 +78,7 @@ updates:
 
   - package-ecosystem: "bundler"
     directories:
-      - "/ruby/src/layer"
+      - "/ruby/src/otel/layer"
       - "/ruby/sample-apps/function"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot was not looking into the correct to search for gem files. 