### PR TITLE
Fix Java release workflow - Make the name of the java wrapper artifact consistent

### DIFF
--- a/.github/workflows/layer-publish.yml
+++ b/.github/workflows/layer-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       artifact-name:
-        description: 'This should correspond to a actions/upload-artifact name earlier in the build.'
+        description: 'This should correspond to a actions/upload-artifact name earlier in the build. The file name and the name of the artifact containing it must be equal.'
         required: true
         type: string
       layer-name:

--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -42,7 +42,7 @@ jobs:
         name: Save javawrapper layer to build
         with:
           name: opentelemetry-javawrapper-layer.zip
-          path: java/layer-wrapper/build/distributions/opentelemetry-java-wrapper.zip
+          path: java/layer-wrapper/build/distributions/opentelemetry-javawrapper-layer.zip
 
       - name: Save Javaagent Version
         id: save-javaagent-version

--- a/java/layer-wrapper/build.gradle.kts
+++ b/java/layer-wrapper/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
 tasks {
     val createLayer by registering(Zip::class) {
-        archiveFileName.set("opentelemetry-java-wrapper.zip")
+        archiveFileName.set("opentelemetry-javawrapper-layer.zip")
         destinationDirectory.set(file("$buildDir/distributions"))
 
         from(configurations["runtimeClasspath"]) {


### PR DESCRIPTION
This has to be done so that the release workflow works properly. 

The name of the artifact in the upload action is just an arbitrary name to identify the artifact and it has nothing to do with the contents of it. https://github.com/actions/upload-artifact?tab=readme-ov-file#zip-archives

