### PR TITLE
Sample spans always in Nodejs sample app

### DIFF
--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -24,6 +24,7 @@ module "hello-lambda-function" {
     OTEL_METRICS_EXPORTER       = "logging"
     OTEL_LOG_LEVEL              = "DEBUG"
     OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/"
+    OTEL_TRACES_SAMPLER         = "always_on"
   }
 
   tracing_mode = var.tracing_mode


### PR DESCRIPTION
Because 
- by default trace context is propagated through AWS XRay in Lambda handlers as long as it is not explicitly disabled (https://github.com/open-telemetry/opentelemetry-js-contrib/blob/de7a6cb77e643ed0de82e514510089fba5ae0405/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts#L395)
- and when AWS XRay tracing mode is `PassThrough`, sampled flag is set to `false` (`0`) (for ex. `Root=1-66ca4895-3f6cef844dab67fb6f6461a4;Parent=27c4bbf84acc163c;Sampled=0;Lineage=d4d48d4d:0`)
- and since default sampling strategy is `parentbased_always_on`, child spans are sampled only if their parent span is sampled
- hence, since propagated parent span context by AWS XRay is not sampled (because AWS XRay tracing mode is configured as `PassThrough` in the example, sampled flag is set to `false` as mentioned above), spans starting from handler span are not sampled and not recorded as well (that is why we see `Recording is off, propagating context in a non-recording span` logs).

So, to fix this issue in the sample Node.js sample app, I have set sampling policy to `always_on` and they will be sampled always even though parent span context by AWS XRay is not sampled.

The alternative solutions might be
- set AWS XRay tracing mode to `Active` [here](https://github.com/open-telemetry/opentelemetry-lambda/blob/1634f8d4ebe8d9aad56f9bea9ea4932badcdde81/nodejs/sample-apps/aws-sdk/deploy/wrapper/variables.tf#L22)
- or disable AWS context propagation for lambda by setting `OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION` env var to `true` in the example (https://github.com/open-telemetry/opentelemetry-js-contrib/blob/de7a6cb77e643ed0de82e514510089fba5ae0405/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts#L86)