### PR TITLE
adding the debug exporter

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -1,18 +1,6 @@
 name: "Continuous Build (Collector)"
 
-on:
-  push:
-    paths:
-      - 'collector/**'
-      - '.github/workflows/ci-collector.yml'
-    branches:
-      - main
-  pull_request:
-    paths:
-      - 'collector/**'
-      - '.github/workflows/ci-collector.yml'
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ Here is a list of community roles with current and previous members:
   - [Anthony Mirabella](https://github.com/Aneurysm9)
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
+

--- a/README.md
+++ b/README.md
@@ -127,4 +127,3 @@ Here is a list of community roles with current and previous members:
   - [Anthony Mirabella](https://github.com/Aneurysm9)
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
-

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -150,6 +150,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.107.0 // indirect
 	go.opentelemetry.io/collector/exporter v0.107.0 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.107.0 // indirect
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0 // indirect
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.107.0 // indirect
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.107.0 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -271,6 +271,8 @@ go.opentelemetry.io/collector/consumer/consumertest v0.107.0 h1:BfjFHHAqbTmCN32a
 go.opentelemetry.io/collector/consumer/consumertest v0.107.0/go.mod h1:qNMedscdVyuxbV+wWUt4yGKQM3c0YEgQJTFeAtGZjRY=
 go.opentelemetry.io/collector/exporter v0.107.0 h1:Ioi2LfB+0HwU8A4kZsL/Lf1PghNlpEdShJal4DRkJ6g=
 go.opentelemetry.io/collector/exporter v0.107.0/go.mod h1:BpiJI2e8qY6kkkF0xpmEgbO102N+VTWd7qBYDFrnm0M=
+go.opentelemetry.io/collector/exporter/debugexporter v0.107.0 h1:q095py+9wKZhAPz2e7LWBAdeAgwelinfGEgTW9iGKMM=
+go.opentelemetry.io/collector/exporter/debugexporter v0.107.0/go.mod h1:Wb4bs9P75pZTsZiabeXbfHm1gzTm0R3aX1vFWivFQZE=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0 h1:R0+duooEsbeInhgnPOFqQb4MNNuO61Qj9wtxx3MWCnE=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0/go.mod h1:PmuS64CkJWmtgWFsb55aVoNlErUYG4ggHizegSjoMuo=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.107.0 h1:4YTLYaihBZh8AdBcEDWrJTYXHtHu3JQagTa53Wu8iKQ=

--- a/collector/lambdacomponents/default.go
+++ b/collector/lambdacomponents/default.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor"
 	"github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
@@ -52,6 +53,7 @@ func Components(extensionID string) (otelcol.Factories, error) {
 	}
 
 	exporters, err := exporter.MakeFactoryMap(
+		debugexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -125,6 +125,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.107.0 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.107.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.107.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.13.0 // indirect
 	go.opentelemetry.io/collector/internal/globalgates v0.107.0 // indirect

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoupleprocessor v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.98.0
 	go.opentelemetry.io/collector/exporter v0.107.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.107.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.107.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.107.0
@@ -125,7 +126,6 @@ require (
 	go.opentelemetry.io/collector/connector v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.107.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.107.0 // indirect
-	go.opentelemetry.io/collector/exporter/debugexporter v0.107.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.107.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.13.0 // indirect
 	go.opentelemetry.io/collector/internal/globalgates v0.107.0 // indirect

--- a/collector/lambdacomponents/go.sum
+++ b/collector/lambdacomponents/go.sum
@@ -253,6 +253,8 @@ go.opentelemetry.io/collector/consumer/consumertest v0.107.0 h1:BfjFHHAqbTmCN32a
 go.opentelemetry.io/collector/consumer/consumertest v0.107.0/go.mod h1:qNMedscdVyuxbV+wWUt4yGKQM3c0YEgQJTFeAtGZjRY=
 go.opentelemetry.io/collector/exporter v0.107.0 h1:Ioi2LfB+0HwU8A4kZsL/Lf1PghNlpEdShJal4DRkJ6g=
 go.opentelemetry.io/collector/exporter v0.107.0/go.mod h1:BpiJI2e8qY6kkkF0xpmEgbO102N+VTWd7qBYDFrnm0M=
+go.opentelemetry.io/collector/exporter/debugexporter v0.107.0 h1:q095py+9wKZhAPz2e7LWBAdeAgwelinfGEgTW9iGKMM=
+go.opentelemetry.io/collector/exporter/debugexporter v0.107.0/go.mod h1:Wb4bs9P75pZTsZiabeXbfHm1gzTm0R3aX1vFWivFQZE=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0 h1:R0+duooEsbeInhgnPOFqQb4MNNuO61Qj9wtxx3MWCnE=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.107.0/go.mod h1:PmuS64CkJWmtgWFsb55aVoNlErUYG4ggHizegSjoMuo=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.107.0 h1:4YTLYaihBZh8AdBcEDWrJTYXHtHu3JQagTa53Wu8iKQ=

--- a/collector/processor/coldstartprocessor/go.mod
+++ b/collector/processor/coldstartprocessor/go.mod
@@ -1,6 +1,7 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor
 
-go 1.21
+go 1.21.0
+
 toolchain go1.22.5
 
 require (


### PR DESCRIPTION

This is my first contrib to this repo so I may need to jump through some hoops. 

I did test this with the python sample app and the otel layer. Testing the lambda, I have this output: 
```
START RequestId: b9706450-ef0e-435b-9a90-d3e0236fac6c Version: $LATEST
{
  "level": "info",
  "ts": 1725940823.9194221,
  "msg": "TracesExporter",
  "kind": "exporter",
  "data_type": "traces",
  "name": "debug",
  "resource spans": 1,
  "spans": 1
}
{
  "level": "info",
  "ts": 1725940823.919484,
  "msg": "ResourceSpans #0\nResource SchemaURL: \nResource attributes:\n     -> telemetry.sdk.language: Str(python)\n     -> telemetry.sdk.name: Str(opentelemetry)\n     -> telemetry.sdk.version: Str(1.26.0)\n     -> cloud.region: Str(us-west-2)\n     -> cloud.provider: Str(aws)\n     -> faas.name: Str(otel-proto)\n     -> faas.version: Str($LATEST)\n     -> faas.instance: Str(2024/09/10/[$LATEST]a4fa69b388da4d0db3590b16b86adcdd)\n     -> service.name: Str(otel-proto)\n     -> telemetry.auto.version: Str(0.47b0)\nScopeSpans #0\nScopeSpans SchemaURL: \nInstrumentationScope opentelemetry.instrumentation.aws_lambda 0.47b0\nSpan #0\n    Trace ID       : d726e0e4498b896b7a11a8d596f82bab\n    Parent ID      : \n    ID             : 5c408cc9f917028c\n    Name           : lambda_function.lambda_handler\n    Kind           : Server\n    Start time     : 2024-09-10 04:00:23.785520591 +0000 UTC\n    End time       : 2024-09-10 04:00:23.91755595 +0000 UTC\n    Status code    : Unset\n    Status message : \nAttributes:\n     -> cloud.resource_id: Str(arn:aws:lambda:us-west-2:123:function:otel-proto)\n     -> faas.invocation_id: Str(b9706450-ef0e-435b-9a90-d3e0236fac6c)\n     -> cloud.account.id: Str(123)\n",
  "kind": "exporter",
  "data_type": "traces",
  "name": "debug"
}
END RequestId: b9706450-ef0e-435b-9a90-d3e0236fac6c
REPORT RequestId: b9706450-ef0e-435b-9a90-d3e0236fac6c	Duration: 193.71 ms	Billed Duration: 194 ms	Memory Size: 128 MB	Max Memory Used: 118 MB	
XRAY TraceId: 1-66dfc457-02aea586197e7211103033dd	SegmentId: 73416dee1bb60744	Sampled: true	
```
Using the following `config.yaml`:
```
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: "localhost:4317"
      http:
        endpoint: "localhost:4318"

exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [logging]
    metrics:
      receivers: [otlp]
      exporters: [logging]
  telemetry:
    metrics:
      address: localhost:8888
```
