### PR TITLE
Rename OPENTELEMETRY_COLLECTOR_CONFIG_FILE to OPENTELEMETRY_COLLECTOR_CONFIG_URI

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -33,7 +33,7 @@ Alternatively, to configure the OpenTelemetry Lambda Extension via CloudFormatio
 
 ## Configuration
 
-By default, OpenTelemetry Collector Lambda layer exports telemetry data to AWS backends. To customize the collector configuration, add a `collector.yaml` to your function and specify its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment file.
+By default, OpenTelemetry Collector Lambda layer exports telemetry data to AWS backends. To customize the collector configuration, add a `collector.yaml` to your function and specify its location via the `OPENTELEMETRY_COLLECTOR_CONFIG_URI` environment file.
 
 Here is a sample configuration file:
 
@@ -56,10 +56,10 @@ service:
       exporters: [logging, otlp]
 ```
 
-Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` will tell the OpenTelemetry extension where to find the collector configuration:
+Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_URI` will tell the OpenTelemetry extension where to find the collector configuration:
 
 ```
-aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/var/task/collector.yaml}
+aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_URI=/var/task/collector.yaml}
 ```
 
 You can configure environment variables via CloudFormation template as well:
@@ -71,11 +71,11 @@ You can configure environment variables via CloudFormation template as well:
       ...
       Environment:
         Variables:
-          OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yaml
+          OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
 ```
 
 In addition to local files, the OpenTelemetry Collector Lambda layer may be configured through HTTP or S3 URIs
-provided in the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` environment variable.  For instance, to load configuration
+provided in the `OPENTELEMETRY_COLLECTOR_CONFIG_URI` environment variable.  For instance, to load configuration
 from an S3 object using a CloudFormation template:
 
 ```yaml
@@ -85,7 +85,7 @@ from an S3 object using a CloudFormation template:
       ...
       Environment:
         Variables:
-          OPENTELEMETRY_COLLECTOR_CONFIG_FILE: s3://<bucket_name>.s3.<region>.amazonaws.com/collector_config.yaml
+          OPENTELEMETRY_COLLECTOR_CONFIG_URI: s3://<bucket_name>.s3.<region>.amazonaws.com/collector_config.yaml
 ```
 
 Loading configuration from S3 will require that the IAM role attached to your function includes read access to the relevant bucket.

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -48,12 +48,25 @@ type Collector struct {
 }
 
 func getConfig(logger *zap.Logger) string {
-	val, ex := os.LookupEnv("OPENTELEMETRY_COLLECTOR_CONFIG_FILE")
-	if !ex {
-		return "/opt/collector-config/config.yaml"
+	val, ex := os.LookupEnv("OPENTELEMETRY_COLLECTOR_CONFIG_URI")
+	if ex {
+		logger.Info("Using config URI from environment variable", zap.String("uri", newVal))
+		return val
 	}
-	logger.Info("Using config URI from environment", zap.String("uri", val))
-	return val
+
+	// The name of the environment variable was changed
+	// This is the old name, kept for backwards compatibility
+	oldVal, oldEx := os.LookupEnv("OPENTELEMETRY_COLLECTOR_CONFIG_FILE")
+	if oldEx {
+		logger.Info("Using config URI from deprecated environment variable", zap.String("uri", oldVal))
+		logger.Warn("The OPENTELEMETRY_COLLECTOR_CONFIG_FILE environment variable is deprecated. Please use OPENTELEMETRY_COLLECTOR_CONFIG_URI instead.")
+		return oldVal
+	}
+
+	// If neither environment variable is set, use the default
+	defaultVal := "/opt/collector-config/config.yaml"
+	logger.Info("Using default config URI", zap.String("uri", defaultVal))
+	return defaultVal
 }
 
 func NewCollector(logger *zap.Logger, factories otelcol.Factories, version string) *Collector {

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -50,7 +50,7 @@ type Collector struct {
 func getConfig(logger *zap.Logger) string {
 	val, ex := os.LookupEnv("OPENTELEMETRY_COLLECTOR_CONFIG_URI")
 	if ex {
-		logger.Info("Using config URI from environment variable", zap.String("uri", newVal))
+		logger.Info("Using config URI from environment variable", zap.String("uri", val))
 		return val
 	}
 

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -28,7 +28,7 @@ module "hello-lambda-function" {
     {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
       OTEL_METRICS_EXPORTER               = "otlp",
-      OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/opt/config.yaml"
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -28,7 +28,7 @@ module "hello-lambda-function" {
     {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
       OTEL_METRICS_EXPORTER               = "otlp",
-      OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/opt/config.yaml"
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI  = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -26,9 +26,9 @@ module "hello-lambda-function" {
       OTEL_METRICS_EXPORTER   = "otlp",
     } :
     {
-      AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
-      OTEL_METRICS_EXPORTER               = "otlp",
-      OPENTELEMETRY_COLLECTOR_CONFIG_URI  = "/opt/config.yaml"
+      AWS_LAMBDA_EXEC_WRAPPER            = "/opt/otel-handler",
+      OTEL_METRICS_EXPORTER              = "otlp",
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/sqs/deploy/agent/main.tf
+++ b/java/sample-apps/sqs/deploy/agent/main.tf
@@ -28,7 +28,7 @@ module "hello-lambda-function" {
     {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
       OTEL_METRICS_EXPORTER               = "otlp",
-      OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/opt/config.yaml"
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/sqs/deploy/agent/main.tf
+++ b/java/sample-apps/sqs/deploy/agent/main.tf
@@ -28,7 +28,7 @@ module "hello-lambda-function" {
     {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
       OTEL_METRICS_EXPORTER               = "otlp",
-      OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/opt/config.yaml"
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI  = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode

--- a/java/sample-apps/sqs/deploy/agent/main.tf
+++ b/java/sample-apps/sqs/deploy/agent/main.tf
@@ -26,9 +26,9 @@ module "hello-lambda-function" {
       OTEL_METRICS_EXPORTER   = "otlp",
     } :
     {
-      AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-handler",
-      OTEL_METRICS_EXPORTER               = "otlp",
-      OPENTELEMETRY_COLLECTOR_CONFIG_URI  = "/opt/config.yaml"
+      AWS_LAMBDA_EXEC_WRAPPER            = "/opt/otel-handler",
+      OTEL_METRICS_EXPORTER              = "otlp",
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI = "/opt/config.yaml"
   })
 
   tracing_mode = var.tracing_mode


### PR DESCRIPTION
As noted in #645, the name of the environment variable to set the collector config URI is confusing, since it does not only accept a file.

This PR renames it to `OPENTELEMETRY_COLLECTOR_CONFIG_URI` to better reflect what it means, while keeping the old name for backwards compatibility, with the new name taking precedence.

Fixes #645.