### PR TITLE
Increase stale-action's operations-per-run

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -22,3 +22,5 @@ jobs:
 
           days-before-stale: 365
           days-before-close: 30
+
+          operations-per-run: 500


### PR DESCRIPTION
We keep getting rate limited, so it's not getting through everything.

This number should be plenty for the size of our repo.