### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -83,8 +83,8 @@ receivers:
       grpc:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   otlp:
     endpoint: { backend endpoint }
 
@@ -92,7 +92,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging, otlp]
+      exporters: [debug, otlp]
 ```
 
 Once the file has been deployed with a Lambda, configuring the `OPENTELEMETRY_COLLECTOR_CONFIG_URI` will tell the OpenTelemetry extension where to find the collector configuration:

--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -7,17 +7,17 @@ receivers:
         endpoint: "localhost:4318"
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
   telemetry:
     metrics:
       address: localhost:8888


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037