### PR TITLE
Remove support to nodejs 16

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - uses: actions/cache@v4
         with:
           path: ~/.npm

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Build
         run: |
@@ -72,7 +72,7 @@ jobs:
       layer-name: opentelemetry-nodejs
       component-version: ${{needs.build-layer.outputs.NODEJS_VERSION}}
       # architecture:
-      runtimes: nodejs16.x nodejs18.x nodejs20.x
+      runtimes: nodejs18.x nodejs20.x
       release-group: prod
       aws_region: ${{ matrix.aws_region }}
     secrets: inherit


### PR DESCRIPTION
This PR removes support to nodejs 16 since this runtime version has been deprecated recently: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported