### PR TITLE
make debug exporter available for custom builds

### DIFF
--- a/collector/lambdacomponents/exporter/debug.go
+++ b/collector/lambdacomponents/exporter/debug.go
@@ -1,0 +1,28 @@
+//go:build lambdacomponents.custom && (lambdacomponents.all || lambdacomponents.exporter.all || lambdacomponents.exporter.debug)
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
+)
+
+func init() {
+	Factories = append(Factories, func(extensionId string) exporter.Factory {
+		return debugexporter.NewFactory()
+	})
+}


### PR DESCRIPTION
This PR makes the debug exporter available for customized builds (https://github.com/open-telemetry/opentelemetry-lambda/pull/1427).

The debug exporter was added to default in https://github.com/open-telemetry/opentelemetry-lambda/pull/1520