### PR TITLE
Upgrade common OTEL packages used by other OTEL packages to prevent having multiple versions of the same OTEL packages

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -2374,9 +2374,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.6.1.tgz",
-      "integrity": "sha512-A/3lqx9xoew7sFi+AVUUVr6VgB7UJ5qqddkKR3gQk9hWLm1R7HUXVJG09cLcZ7DMNpX13DohPRGmHE/vp1vafw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.6.2.tgz",
+      "integrity": "sha512-xxT6PVmcBTtCo0rf4Bv/mnDMpVRITVt13bDX8mOqKVb0kr5EwIMabZS5EGJhXjP4nljrOIA7ZlOJgSX0Kehfkw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.10.0",
@@ -14235,7 +14235,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.53.0",
         "@opentelemetry/auto-configuration-propagators": "^0.3.0",
-        "@opentelemetry/core": "^1.25.1",
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/exporter-logs-otlp-proto": "^0.53.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.53.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",
@@ -14255,13 +14255,13 @@
         "@opentelemetry/instrumentation-net": "^0.39.0",
         "@opentelemetry/instrumentation-pg": "^0.44.0",
         "@opentelemetry/instrumentation-redis": "^0.42.0",
-        "@opentelemetry/propagator-aws-xray": "^1.25.1",
-        "@opentelemetry/resource-detector-aws": "^1.5.2",
-        "@opentelemetry/resources": "^1.25.1",
+        "@opentelemetry/propagator-aws-xray": "^1.26.0",
+        "@opentelemetry/resource-detector-aws": "^1.6.2",
+        "@opentelemetry/resources": "^1.26.0",
         "@opentelemetry/sdk-logs": "^0.53.0",
-        "@opentelemetry/sdk-metrics": "^1.25.1",
-        "@opentelemetry/sdk-trace-base": "^1.25.1",
-        "@opentelemetry/sdk-trace-node": "^1.25.1"
+        "@opentelemetry/sdk-metrics": "^1.26.0",
+        "@opentelemetry/sdk-trace-base": "^1.26.0",
+        "@opentelemetry/sdk-trace-node": "^1.26.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/api-logs": "^0.53.0",
     "@opentelemetry/exporter-logs-otlp-proto": "^0.53.0",
     "@opentelemetry/auto-configuration-propagators": "^0.3.0",
-    "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.53.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",
     "@opentelemetry/instrumentation": "^0.53.0",
@@ -50,13 +50,13 @@
     "@opentelemetry/instrumentation-net": "^0.39.0",
     "@opentelemetry/instrumentation-pg": "^0.44.0",
     "@opentelemetry/instrumentation-redis": "^0.42.0",
-    "@opentelemetry/propagator-aws-xray": "^1.25.1",
-    "@opentelemetry/resource-detector-aws": "^1.5.2",
-    "@opentelemetry/resources": "^1.25.1",
+    "@opentelemetry/propagator-aws-xray": "^1.26.0",
+    "@opentelemetry/resource-detector-aws": "^1.6.2",
+    "@opentelemetry/resources": "^1.26.0",
     "@opentelemetry/sdk-logs": "^0.53.0",
-    "@opentelemetry/sdk-metrics": "^1.25.1",
-    "@opentelemetry/sdk-trace-base": "^1.25.1",
-    "@opentelemetry/sdk-trace-node": "^1.25.1"
+    "@opentelemetry/sdk-metrics": "^1.26.0",
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
+    "@opentelemetry/sdk-trace-node": "^1.26.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.7",


### PR DESCRIPTION
Without this fix, it is very likely to hit the package size limit which puts `250 MB` limit (unzipped) for the contents of a deployment package, including layers and custom runtimes. 

This fix also helps to reduce the coldstart delay by reducing the deployment artifact size.

Compressed Size
=====
**Before fix (`v0.10.0`):** `38.5 MB`
**After fix:** `8.5 MB`

`78%` package size improvement.

Uncompressed Size (On Disk)
=====
**Before fix (`v0.10.0`):** `202.1 MB`
**After fix:** `42.6 MB`

`79%` package size improvement.