### PR TITLE
fix: remove deprecated expandconverter

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.112.0
 	go.opentelemetry.io/collector/confmap v1.18.0
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.112.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.18.0
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.18.0
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.18.0

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -285,8 +285,6 @@ go.opentelemetry.io/collector/config/internal v0.112.0 h1:kB28u5IrrJIsKKHFltBSAr
 go.opentelemetry.io/collector/config/internal v0.112.0/go.mod h1:yC7E4h1Uj0SubxcFImh6OvBHFTjMh99+A5PuyIgDWqc=
 go.opentelemetry.io/collector/confmap v1.18.0 h1:UEOeJY8RW8lZ1O4lzHSGqolS7uzkpXQi5fa8SidKqQg=
 go.opentelemetry.io/collector/confmap v1.18.0/go.mod h1:GgNu1ElPGmLn9govqIfjaopvdspw4PJ9KeDtWC4E2Q4=
-go.opentelemetry.io/collector/confmap/converter/expandconverter v0.112.0 h1:OsoXXLq+esPFSLZm+ar/0XjR5p7Am4WTSXIth9Wpa38=
-go.opentelemetry.io/collector/confmap/converter/expandconverter v0.112.0/go.mod h1:BQdUghbxnpSYai6VBm6SsedndXVC9vlGM2N1Fc/0rnk=
 go.opentelemetry.io/collector/confmap/provider/envprovider v1.18.0 h1:ZWEsXeCbNUP4GXRvlkVXBpqIH9rNtnk1knZDORo/7zA=
 go.opentelemetry.io/collector/confmap/provider/envprovider v1.18.0/go.mod h1:76mYXizxjo8rcRsvyTuNtPykVuqmZWGcV6lGs7+++J8=
 go.opentelemetry.io/collector/confmap/provider/fileprovider v1.18.0 h1:eTDRt5w/bTaTWOY/satyprh/7V0zkwLKvm6NQuJ/L+8=

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -23,7 +23,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
@@ -76,7 +75,6 @@ func NewCollector(logger *zap.Logger, factories otelcol.Factories, version strin
 			URIs:              []string{getConfig(l)},
 			ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory(), envprovider.NewFactory(), yamlprovider.NewFactory(), httpprovider.NewFactory(), s3provider.NewFactory(), secretsmanagerprovider.NewFactory()},
 			ConverterFactories: []confmap.ConverterFactory{
-				expandconverter.NewFactory(),
 				confmap.NewConverterFactory(func(set confmap.ConverterSettings) confmap.Converter {
 					return disablequeuedretryconverter.New()
 				}),


### PR DESCRIPTION
The `expandconverter` is deprecated as of 0.107.0 and leaving it enabled causes issues with the parsing of environment variables. For example, when supplying an identifier like `'1234'` to a string field through an environment variable, this would incorrectly be treated as an integer and fail validation.