### PR TITLE
feat: add httpsprovider

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.19.0
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.19.0
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.19.0
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.19.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.19.0
 	go.opentelemetry.io/collector/otelcol v0.113.0
 	go.uber.org/multierr v1.11.0
@@ -93,7 +94,7 @@ require (
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
-	github.com/knadh/koanf/v2 v2.1.1 // indirect
+	github.com/knadh/koanf/v2 v2.1.2 // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magefile/mage v1.15.0 // indirect

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -129,8 +129,8 @@ github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NI
 github.com/knadh/koanf/maps v0.1.1/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/knadh/koanf/providers/confmap v0.1.0 h1:gOkxhHkemwG4LezxxN8DMOFopOPghxRVp7JbIvdvqzU=
 github.com/knadh/koanf/providers/confmap v0.1.0/go.mod h1:2uLhxQzJnyHKfxG927awZC7+fyHFdQkd697K4MdLnIU=
-github.com/knadh/koanf/v2 v2.1.1 h1:/R8eXqasSTsmDCsAyYj+81Wteg8AqrV9CP6gvsTsOmM=
-github.com/knadh/koanf/v2 v2.1.1/go.mod h1:4mnTRbZCK+ALuBXHZMjDfG9y714L7TykVnZkXbMU3Es=
+github.com/knadh/koanf/v2 v2.1.2 h1:I2rtLRqXRy1p01m/utEtpZSSA6dcJbgGVuE27kW2PzQ=
+github.com/knadh/koanf/v2 v2.1.2/go.mod h1:Gphfaen0q1Fc1HTgJgSTC4oRX9R2R5ErYMZJy8fLJBo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -291,6 +291,8 @@ go.opentelemetry.io/collector/confmap/provider/fileprovider v1.19.0 h1:TYwyk4ea3
 go.opentelemetry.io/collector/confmap/provider/fileprovider v1.19.0/go.mod h1:i3mL4OSGI5JM0hnzHujhJK+LDlvO3XrJxBsuclfU/jY=
 go.opentelemetry.io/collector/confmap/provider/httpprovider v1.19.0 h1:a077jcs3DVtaVdmgmCk3x4rRYuTkIqMDsoUc+VICHZk=
 go.opentelemetry.io/collector/confmap/provider/httpprovider v1.19.0/go.mod h1:HjYkzhHbwUacv27nq0JLsslGpbtrXyyfU30Oc72AWLU=
+go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.19.0 h1:8LoQxjlduFQUEwYuHWnxEj0A+GcAtpv2qPpDJVz7A5E=
+go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.19.0/go.mod h1:Y8ErEl5m9+1AWzWcMn52PATH5dw50wuyyPMffK62RCI=
 go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.19.0 h1:oV66DKiEdAt8EMZqGSChK2iEOxjrVaWRhf4OqqmqjbM=
 go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.19.0/go.mod h1:jtNUdO6i1k38BG7vFst+d1jk/N+c419uVR8HB4J0VjI=
 go.opentelemetry.io/collector/connector v0.113.0 h1:ii+s1CjsLxtglqRlFs6tv8UU/uX45dyN9lbTRbR0p8g=

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
+	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
 	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.uber.org/zap"
@@ -73,7 +74,7 @@ func NewCollector(logger *zap.Logger, factories otelcol.Factories, version strin
 	cfgSet := otelcol.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs:              []string{getConfig(l)},
-			ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory(), envprovider.NewFactory(), yamlprovider.NewFactory(), httpprovider.NewFactory(), s3provider.NewFactory(), secretsmanagerprovider.NewFactory()},
+			ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory(), envprovider.NewFactory(), yamlprovider.NewFactory(), httpsprovider.NewFactory(), httpprovider.NewFactory(), s3provider.NewFactory(), secretsmanagerprovider.NewFactory()},
 			ConverterFactories: []confmap.ConverterFactory{
 				confmap.NewConverterFactory(func(set confmap.ConverterSettings) confmap.Converter {
 					return disablequeuedretryconverter.New()


### PR DESCRIPTION
Adds the [httpsprovider](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/httpsprovider) to also support `https://` as scheme in `OPENTELEMETRY_COLLECTOR_CONFIG_URI`.