### PR TITLE
honor initial set zap loglevel

### DIFF
--- a/collector/main.go
+++ b/collector/main.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle"
 	"os"
+
+	"github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -57,11 +58,15 @@ func main() {
 
 func initLogger() *zap.Logger {
 	lvl := zap.NewAtomicLevelAt(zapcore.InfoLevel)
-
 	envLvl := os.Getenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")
-	userLvl, err := zap.ParseAtomicLevel(envLvl)
-	if err == nil {
-		lvl = userLvl
+	// When not set, Getenv returns empty string
+	var err error
+	if envLvl != "" {
+		var userLvl zap.AtomicLevel
+		userLvl, err = zap.ParseAtomicLevel(envLvl)
+		if err == nil {
+			lvl = userLvl
+		}
 	}
 
 	l := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), os.Stdout, lvl))


### PR DESCRIPTION
`os.Getenv("OPENTELEMETRY_EXTENSION_LOG_LEVEL")` returns an empty string when the env var is not set. `zap.ParseAtomicLevel("")` will return info log level.

This means  line `lvl := zap.NewAtomicLevelAt(zapcore.InfoLevel)` is never used.
This PR fixes this.