### PR TITLE
NodeJS runtime support for nodejs22.x

### DIFF
--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -87,7 +87,7 @@ jobs:
       layer-name: opentelemetry-nodejs
       component-version: ${{needs.build-layer.outputs.NODEJS_VERSION}}
       # architecture:
-      runtimes: nodejs18.x nodejs20.x
+      runtimes: nodejs18.x nodejs20.x nodejs22.x
       release-group: prod
       aws_region: ${{ matrix.aws_region }}
     secrets: inherit

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -47,12 +47,12 @@ package: build
 
 .PHONY: publish
 publish:
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs14.x nodejs16.x nodejs18.x java11 python3.8 python3.9 python3.10 python3.11 python3.12 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 python3.8 python3.9 python3.10 python3.11 python3.12 --query 'LayerVersionArn' --output text
 
 .PHONY: publish-layer
 publish-layer: package
 	@echo Publishing collector extension layer...
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs14.x nodejs16.x nodejs18.x java11 python3.8 python3.9 python3.10 python3.11 python3.12 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 python3.8 python3.9 python3.10 python3.11 python3.12 --query 'LayerVersionArn' --output text
 	@echo OpenTelemetry Collector layer published.
 
 .PHONY: set-otelcol-version

--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -5,7 +5,7 @@ module "hello-lambda-function" {
   architectures = compact([var.architecture])
   function_name = var.name
   handler       = "index.handler"
-  runtime       = "nodejs16.x"
+  runtime       = var.runtime
 
   create_package         = false
   local_existing_package = "${path.module}/../../build/function.zip"
@@ -51,4 +51,3 @@ module "api-gateway" {
   function_invoke_arn = module.hello-lambda-function.lambda_function_invoke_arn
   enable_xray_tracing = var.tracing_mode == "Active"
 }
-

--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -27,3 +27,10 @@ variable "architecture" {
   description = "Lambda function architecture, valid values are arm64 or x86_64"
   default     = "x86_64"
 }
+
+variable "runtime" {
+  type        = string
+  description = "NodeJS runtime version used for sample Lambda Function"
+  default     = "nodejs18.x"
+}
+


### PR DESCRIPTION
PR to nodejs runtime support for nodejs20.x, nodejs22.x
- changes to sample app to provide runtime as variable.
otel-js is [moving towards following runtimes](https://github.com/open-telemetry/opentelemetry-js?tab=readme-ov-file#supported-runtimes)