### PR TITLE
fix(extension): consider requests failed when status code is not 2xx

### DIFF
--- a/collector/internal/extensionapi/client.go
+++ b/collector/internal/extensionapi/client.go
@@ -180,7 +180,7 @@ func (e *Client) doRequest(req *http.Request, out interface{}) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("request failed with status %s", resp.Status)
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
This updates the extension api client to consider requests as failed only when their status code is not 2xx. This is mostly required since AWS Lambda has updated the status code returned on successful extension registration from 200 to 201 and thus all lambda invocations fail. 