### PR TITLE
feat(collector): add manual collector build workflow

### DIFF
--- a/.github/workflows/build-collector.yml
+++ b/.github/workflows/build-collector.yml
@@ -1,0 +1,27 @@
+name: "Manual Build (Collector)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [ amd64, arm64 ]
+    outputs:
+      COLLECTOR_VERSION: ${{ steps.save-collector-version.outputs.COLLECTOR_VERSION }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.21.9'
+      - name: Build Collector
+        run: make -C collector package GOARCH=${{ matrix.architecture }}
+      - name: Upload Collector Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
+          path: ${{ github.workspace }}/collector/build/opentelemetry-collector-layer-${{ matrix.architecture }}.zip


### PR DESCRIPTION
The motivation of this PR is being able to build collector binaries from working branches. 

For example, if you don't have a local environment to produce Lambda collector binaries for both `amd64` and/or `arm64` architectures to test in the real Lambda environment, you can use this workflow in your own fork/branch to build your custom collector binaries.

In the later PRs, this workflow will be enhanced by supporting
- build tags, so custom collector binary will be able to built
- deploying as layer to the specified AWS account
- etc ...