### PR TITLE
feat(nodejs): minimize out-of-the-box supported propagators to reduce coldstart delay

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1616,17 +1616,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.0.tgz",
-      "integrity": "sha512-roCetrG/cz0r/gugQm/jFo75UxblVvHaNSRoR0kSSRSzXFAiIBqFCZuH458BHBNRtRe+0yJdIJ21L9t94bw7+g==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/core": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
@@ -2053,34 +2042,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.0.tgz",
-      "integrity": "sha512-lcobQQmd+hLdtxJJKu/i51lNXmF1PJJ7Y9B97ciHRVQuMI260vSZG7Uf4Zg0fqR8PB+fT/7rnlDwS0M7QldZQQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.0.tgz",
-      "integrity": "sha512-0hdP495V6HPRkVpowt54+Swn5NdesMIRof+rlp0mbnuIUOM986uF+eNxnPo9q5MmJegVBRTxgMHXXwvnXRnKRg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/redis-common": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
@@ -2181,25 +2142,6 @@
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.0.tgz",
-      "integrity": "sha512-MeXkXEdBs9xq1JSGTr/3P1lHBSUBaVmo1+UpoQhUpviPMzDXy0MNsdTC7KKI6/YcG74lTX6eqeNjlC1jV4Rstw==",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.30.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/propagator-b3": "1.30.0",
-        "@opentelemetry/propagator-jaeger": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -13865,6 +13807,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.57.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
         "@opentelemetry/core": "^1.30.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
@@ -13891,8 +13834,7 @@
         "@opentelemetry/resources": "^1.30.0",
         "@opentelemetry/sdk-logs": "^0.57.0",
         "@opentelemetry/sdk-metrics": "^1.30.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.0",
-        "@opentelemetry/sdk-trace-node": "^1.30.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.9",
@@ -13902,7 +13844,18 @@
         "ts-node": "^10.9.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/layer/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "sample-apps/aws-sdk": {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1616,25 +1616,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@opentelemetry/auto-configuration-propagators": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-configuration-propagators/-/auto-configuration-propagators-0.3.2.tgz",
-      "integrity": "sha512-c+vtrYggJFozGcmUQdbe9xoUFTFaXJahrXIrie/QGfKmYgCf5eexuBE19ag9V1+t9Il7fIlABv1WYZfFDQ1aLA==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.25.1",
-        "@opentelemetry/propagator-aws-xray": "^1.26.1",
-        "@opentelemetry/propagator-aws-xray-lambda": "^0.53.1",
-        "@opentelemetry/propagator-b3": "^1.25.1",
-        "@opentelemetry/propagator-jaeger": "^1.25.1",
-        "@opentelemetry/propagator-ot-trace": "^0.27.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.4.1"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.0.tgz",
@@ -2098,17 +2079,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-ot-trace": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-ot-trace/-/propagator-ot-trace-0.27.2.tgz",
-      "integrity": "sha512-6ynu2LfTF8vjYn4BcTmT5wiIp5JY6ELNuihfUJ9D2gmm/SLxI4COygvAoDHliyEKZy1yznmcWDJPTPW+9waawg==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -13895,7 +13865,6 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.57.0",
-        "@opentelemetry/auto-configuration-propagators": "^0.3.2",
         "@opentelemetry/core": "^1.30.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
@@ -13917,6 +13886,7 @@
         "@opentelemetry/instrumentation-pg": "^0.50.0",
         "@opentelemetry/instrumentation-redis": "^0.46.0",
         "@opentelemetry/propagator-aws-xray": "^1.26.0",
+        "@opentelemetry/propagator-aws-xray-lambda": "^0.53.1",
         "@opentelemetry/resource-detector-aws": "^1.10.0",
         "@opentelemetry/resources": "^1.30.0",
         "@opentelemetry/sdk-logs": "^0.57.0",

--- a/nodejs/packages/layer/package-lock.json
+++ b/nodejs/packages/layer/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.57.0",
-        "@opentelemetry/auto-configuration-propagators": "^0.3.2",
         "@opentelemetry/core": "^1.30.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
@@ -33,6 +32,7 @@
         "@opentelemetry/instrumentation-pg": "^0.50.0",
         "@opentelemetry/instrumentation-redis": "^0.46.0",
         "@opentelemetry/propagator-aws-xray": "^1.26.0",
+        "@opentelemetry/propagator-aws-xray-lambda": "^0.53.1",
         "@opentelemetry/resource-detector-aws": "^1.10.0",
         "@opentelemetry/resources": "^1.30.0",
         "@opentelemetry/sdk-logs": "^0.57.0",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.0.tgz",
-      "integrity": "sha512-l1aJ30CXeauVYaI+btiynHpw341LthkMTv3omi1VJDX14werY2Wmv9n1yudMsq9HuY0m8PvXEVX4d8zxEb+WRg==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
+      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -124,29 +124,10 @@
         "node": ">=14"
       }
     },
-    "node_modules/@opentelemetry/auto-configuration-propagators": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-configuration-propagators/-/auto-configuration-propagators-0.3.2.tgz",
-      "integrity": "sha512-c+vtrYggJFozGcmUQdbe9xoUFTFaXJahrXIrie/QGfKmYgCf5eexuBE19ag9V1+t9Il7fIlABv1WYZfFDQ1aLA==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.25.1",
-        "@opentelemetry/propagator-aws-xray": "^1.26.1",
-        "@opentelemetry/propagator-aws-xray-lambda": "^0.53.1",
-        "@opentelemetry/propagator-b3": "^1.25.1",
-        "@opentelemetry/propagator-jaeger": "^1.25.1",
-        "@opentelemetry/propagator-ot-trace": "^0.27.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.4.1"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.0.tgz",
-      "integrity": "sha512-roCetrG/cz0r/gugQm/jFo75UxblVvHaNSRoR0kSSRSzXFAiIBqFCZuH458BHBNRtRe+0yJdIJ21L9t94bw7+g==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "engines": {
         "node": ">=14"
       },
@@ -155,9 +136,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -169,15 +150,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.57.0.tgz",
-      "integrity": "sha512-F3KfPwDheOWpwjwIZJNg9J6ULSRcw39FtQ+c/fUv5xiKE7hu96udTSUoWRmHRJDQ2x9kZLLOOUMd5U/NyP25jw==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.57.1.tgz",
+      "integrity": "sha512-u8Cr6yDX57/n89aSJwAQNHQIYodcl6o8jTcaPKNktMvNfd7ny3R7aE7GKBC5Wg0zejP9heBgyN0OGwrPhptx7A==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/otlp-exporter-base": "0.57.0",
-        "@opentelemetry/otlp-transformer": "0.57.0",
-        "@opentelemetry/sdk-logs": "0.57.0"
+        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.1",
+        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/sdk-logs": "0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -187,15 +168,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.0.tgz",
-      "integrity": "sha512-uxCiTVFAQ1kLy8SS0vyNNXRqH69htbtTxk4EEB2H4CvBFt3pA2N22k6SFF5fOdvDwUvM7Mi9mUfW48rS4Y0F8g==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.1.tgz",
+      "integrity": "sha512-jpKYVZY7fdwTdy+eAy/Mp9DZMaQpj7caMzlo3QqQDSJx5FZEY6zWzgcKvDvF6h+gdHE7LgUjaPOvJVUs354jJg==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/otlp-exporter-base": "0.57.0",
-        "@opentelemetry/otlp-transformer": "0.57.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/sdk-metrics": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.1",
+        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-metrics": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -205,15 +186,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.0.tgz",
-      "integrity": "sha512-BJl35PSkwoMlGEOrzjCG1ih6zqZoAZJIR4xyqSKC2BqPtwuRjID0vWBaEdP9xrxxJTEIEQw+gEY/0pUgicX0ew==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.1.tgz",
+      "integrity": "sha512-43dLEjlf6JGxpVt9RaRlJAvjHG1wGsbAuNd67RIDy/95zfKk2aNovtiGUgFdS/kcvgvS90upIUbgn0xUd9JjMg==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/otlp-exporter-base": "0.57.0",
-        "@opentelemetry/otlp-transformer": "0.57.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.1",
+        "@opentelemetry/otlp-transformer": "0.57.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -223,11 +204,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.0.tgz",
-      "integrity": "sha512-qIKp+tSCLqofneUWRc5XHtr9jHIq0N0BJfaJamM9gjEFO8sthV4SDXDGNOSAx16PxkbrQJ5/AxMPAGCXl8W/Hg==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
+      "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.0",
+        "@opentelemetry/api-logs": "0.57.1",
         "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -319,11 +300,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.0.tgz",
-      "integrity": "sha512-dUebqefKDS1DlUZ7SUEUUbvRd8CwQmHGc4B12+RtJZoABUc9dFYpPBieRpHbf6sOmZXnfcU6jimZrVZoqi3rCg==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.1.tgz",
+      "integrity": "sha512-tZ0LO6hxLCnQfSS03BpYWc+kZpqFJJUbYb+GfEr5YJ1/YrOtRP8lCpC8AC1QIVmqGn+Vlxjkn3tSifNHsk9enw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.57.0",
+        "@opentelemetry/instrumentation": "0.57.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -350,12 +331,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.0.tgz",
-      "integrity": "sha512-GJD6e/YSSZUI/xZokK9L+ghMAyFrtGV+8HHXCnV8tDYCo66biLpmC9BUTg6fBnv26QsosYvFTYbdo6Sfn6TxCw==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
+      "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/instrumentation": "0.57.0",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.1",
         "@opentelemetry/semantic-conventions": "1.28.0",
         "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
@@ -489,12 +470,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.0.tgz",
-      "integrity": "sha512-QQl4Ngm3D6H8SDO0EM642ncTxjRsf/HDq7+IWIA0eaEK/NTsJeQ3iYJiZj3F4jkALnvyeM1kkwd+DHtqxTBx9Q==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.1.tgz",
+      "integrity": "sha512-GNBJAEYfeiYJQ3O2dvXgiNZ/qjWrBxSb1L1s7iV/jKBRGMN3Nv+miTk2SLeEobF5E5ZK4rVcHKlBZ71bPVIv/g==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/otlp-transformer": "0.57.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-transformer": "0.57.1"
       },
       "engines": {
         "node": ">=14"
@@ -504,16 +485,16 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.0.tgz",
-      "integrity": "sha512-yHX7sdwkdAmSa6Jbi3caSLDWy0PCHS1pKQeKz8AIWSyQqL7IojHKgdk9A+7eRd98Z1n9YTdwWSWLnObvIqhEhQ==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.1.tgz",
+      "integrity": "sha512-EX67y+ukNNfFrOLyjYGw8AMy0JPIlEX1dW60SGUNZWW2hSQyyolX7EqFuHP5LtXLjJHNfzx5SMBVQ3owaQCNDw==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/sdk-logs": "0.57.0",
-        "@opentelemetry/sdk-metrics": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
+        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-logs": "0.57.1",
+        "@opentelemetry/sdk-metrics": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
         "protobufjs": "^7.3.0"
       },
       "engines": {
@@ -560,11 +541,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.0.tgz",
-      "integrity": "sha512-lcobQQmd+hLdtxJJKu/i51lNXmF1PJJ7Y9B97ciHRVQuMI260vSZG7Uf4Zg0fqR8PB+fT/7rnlDwS0M7QldZQQ==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+      "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0"
+        "@opentelemetry/core": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -574,28 +555,17 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.0.tgz",
-      "integrity": "sha512-0hdP495V6HPRkVpowt54+Swn5NdesMIRof+rlp0mbnuIUOM986uF+eNxnPo9q5MmJegVBRTxgMHXXwvnXRnKRg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+      "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0"
+        "@opentelemetry/core": "1.30.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-ot-trace": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-ot-trace/-/propagator-ot-trace-0.27.2.tgz",
-      "integrity": "sha512-6ynu2LfTF8vjYn4BcTmT5wiIp5JY6ELNuihfUJ9D2gmm/SLxI4COygvAoDHliyEKZy1yznmcWDJPTPW+9waawg==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -623,11 +593,11 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -638,13 +608,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.0.tgz",
-      "integrity": "sha512-6Kbxdu/QE9LWH7+WSLmYo3DjAq+c55TiCLXiXu6b/2m2muy5SyOG2m0MrGqetyRpfYSSbIqHmJoqNVTN3+2a9g==",
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.1.tgz",
+      "integrity": "sha512-jGdObb/BGWu6Peo3cL3skx/Rl1Ak/wDDO3vpPrrThGbqE7isvkCsX6uE+OAt8Ayjm9YC8UGkohWbLR09JmM0FA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
+        "@opentelemetry/api-logs": "0.57.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -654,12 +624,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.0.tgz",
-      "integrity": "sha512-5kcj6APyRMvv6dEIP5plz2qfJAD4OMipBRT11u/pa1a68rHKI2Ln+iXVkAGKgx8o7CXbD7FdPypTUY88ZQgP4Q==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
       },
       "engines": {
         "node": ">=14"
@@ -669,12 +639,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.0.tgz",
-      "integrity": "sha512-RKQDaDIkV7PwizmHw+rE/FgfB2a6MBx+AEVVlAHXRG1YYxLiBpPX2KhmoB99R5vA4b72iJrjle68NDWnbrE9Dg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -685,15 +655,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.0.tgz",
-      "integrity": "sha512-MeXkXEdBs9xq1JSGTr/3P1lHBSUBaVmo1+UpoQhUpviPMzDXy0MNsdTC7KKI6/YcG74lTX6eqeNjlC1jV4Rstw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+      "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.30.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/propagator-b3": "1.30.0",
-        "@opentelemetry/propagator-jaeger": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
+        "@opentelemetry/context-async-hooks": "1.30.1",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/propagator-b3": "1.30.1",
+        "@opentelemetry/propagator-jaeger": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -877,9 +847,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
       "dependencies": {
         "undici-types": "~6.20.0"
       }

--- a/nodejs/packages/layer/package-lock.json
+++ b/nodejs/packages/layer/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.57.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
         "@opentelemetry/core": "^1.30.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
@@ -37,8 +38,7 @@
         "@opentelemetry/resources": "^1.30.0",
         "@opentelemetry/sdk-logs": "^0.57.0",
         "@opentelemetry/sdk-metrics": "^1.30.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.0",
-        "@opentelemetry/sdk-trace-node": "^1.30.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.9",
@@ -48,7 +48,7 @@
         "ts-node": "^10.9.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -540,34 +540,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
-      "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
-      "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/redis-common": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
@@ -646,25 +618,6 @@
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
-      "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.30.1",
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/propagator-b3": "1.30.1",
-        "@opentelemetry/propagator-jaeger": "1.30.1",
-        "@opentelemetry/sdk-trace-base": "1.30.1",
-        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=14"

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -28,11 +28,12 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.57.0",
+    "@opentelemetry/context-async-hooks": "^1.30.1",
     "@opentelemetry/core": "^1.30.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
@@ -59,8 +60,7 @@
     "@opentelemetry/resources": "^1.30.0",
     "@opentelemetry/sdk-logs": "^0.57.0",
     "@opentelemetry/sdk-metrics": "^1.30.0",
-    "@opentelemetry/sdk-trace-base": "^1.30.0",
-    "@opentelemetry/sdk-trace-node": "^1.30.0"
+    "@opentelemetry/sdk-trace-base": "^1.30.0"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.9",

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.57.0",
-    "@opentelemetry/auto-configuration-propagators": "^0.3.2",
     "@opentelemetry/core": "^1.30.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
@@ -55,6 +54,7 @@
     "@opentelemetry/instrumentation-pg": "^0.50.0",
     "@opentelemetry/instrumentation-redis": "^0.46.0",
     "@opentelemetry/propagator-aws-xray": "^1.26.0",
+    "@opentelemetry/propagator-aws-xray-lambda": "^0.53.1",
     "@opentelemetry/resource-detector-aws": "^1.10.0",
     "@opentelemetry/resources": "^1.30.0",
     "@opentelemetry/sdk-logs": "^0.57.0",

--- a/nodejs/packages/layer/src/LambdaTracerProvider.ts
+++ b/nodejs/packages/layer/src/LambdaTracerProvider.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import {
+  BasicTracerProvider,
+  PROPAGATOR_FACTORY,
+  SDKRegistrationConfig,
+  TracerConfig,
+} from '@opentelemetry/sdk-trace-base';
+
+export class LambdaTracerProvider extends BasicTracerProvider {
+  protected static override readonly _registeredPropagators = new Map<
+    string,
+    PROPAGATOR_FACTORY
+  >([...BasicTracerProvider._registeredPropagators]);
+  constructor(config: TracerConfig = {}) {
+    super(config);
+  }
+  override register(config: SDKRegistrationConfig = {}): void {
+    if (config.contextManager === undefined) {
+      config.contextManager = new AsyncLocalStorageContextManager();
+      config.contextManager.enable();
+    }
+    super.register(config);
+  }
+}

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -16,15 +16,13 @@ import {
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
 import {
+  BasicTracerProvider,
   BatchSpanProcessor,
   ConsoleSpanExporter,
   SDKRegistrationConfig,
   SimpleSpanProcessor,
+  TracerConfig,
 } from '@opentelemetry/sdk-trace-base';
-import {
-  NodeTracerConfig,
-  NodeTracerProvider,
-} from '@opentelemetry/sdk-trace-node';
 import {
   MeterProvider,
   MeterProviderOptions,
@@ -60,6 +58,8 @@ import {
 import { AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
 import { AWSXRayLambdaPropagator } from '@opentelemetry/propagator-aws-xray-lambda';
 
+import { LambdaTracerProvider } from './LambdaTracerProvider';
+
 const defaultInstrumentationList = [
   'dns',
   'express',
@@ -88,8 +88,8 @@ declare global {
   function configureAwsInstrumentation(
     defaultConfig: AwsSdkInstrumentationConfig,
   ): AwsSdkInstrumentationConfig;
-  function configureTracerProvider(tracerProvider: NodeTracerProvider): void;
-  function configureTracer(defaultConfig: NodeTracerConfig): NodeTracerConfig;
+  function configureTracerProvider(tracerProvider: BasicTracerProvider): void;
+  function configureTracer(defaultConfig: TracerConfig): TracerConfig;
   function configureSdkRegistration(
     defaultSdkRegistration: SDKRegistrationConfig,
   ): SDKRegistrationConfig;
@@ -269,14 +269,14 @@ function initializeProvider() {
     detectors: [awsLambdaDetector, envDetector, processDetector],
   });
 
-  let config: NodeTracerConfig = {
+  let config: TracerConfig = {
     resource,
   };
   if (typeof configureTracer === 'function') {
     config = configureTracer(config);
   }
 
-  const tracerProvider = new NodeTracerProvider(config);
+  const tracerProvider = new LambdaTracerProvider(config);
   if (typeof configureTracerProvider === 'function') {
     configureTracerProvider(tracerProvider);
   } else {

--- a/nodejs/packages/layer/test/wrapper.spec.ts
+++ b/nodejs/packages/layer/test/wrapper.spec.ts
@@ -1,22 +1,33 @@
 import type { AwsSdkInstrumentationConfig } from '@opentelemetry/instrumentation-aws-sdk';
-import { stub } from 'sinon';
+import { SDKRegistrationConfig } from '@opentelemetry/sdk-trace-base';
+import { TextMapPropagator } from '@opentelemetry/api';
 
 import { wrap, unwrap } from '../src/wrapper';
+
+import { stub } from 'sinon';
+import assert from 'assert';
 
 declare global {
   function configureAwsInstrumentation(
     defaultConfig: AwsSdkInstrumentationConfig,
   ): AwsSdkInstrumentationConfig;
+  function configureSdkRegistration(
+    defaultSdkRegistration: SDKRegistrationConfig,
+  ): SDKRegistrationConfig;
 }
 
-const assert = require('assert');
-
 describe('wrapper', () => {
+  let oldEnv: NodeJS.ProcessEnv;
+
   beforeEach(() => {
+    oldEnv = { ...process.env };
+
     unwrap();
   });
 
   afterEach(() => {
+    process.env = oldEnv;
+
     unwrap();
   });
 
@@ -28,6 +39,66 @@ describe('wrapper', () => {
       global.configureAwsInstrumentation = configureAwsInstrumentationStub;
       wrap();
       assert(configureAwsInstrumentationStub.calledOnce);
+    });
+  });
+
+  describe('getPropagator', () => {
+    const testConfiguredPropagator = (
+      propagatorNames: string[],
+      expectedPropagatorFields: string[],
+    ) => {
+      if (propagatorNames && propagatorNames.length) {
+        process.env.OTEL_PROPAGATORS = propagatorNames.join(',');
+      }
+
+      const configureSdkRegistrationStub = stub().returnsArg(0);
+      global.configureSdkRegistration = configureSdkRegistrationStub;
+      wrap();
+      assert(configureSdkRegistrationStub.calledOnce);
+
+      const sdkRegistrationConfig: SDKRegistrationConfig =
+        configureSdkRegistrationStub.getCall(0).firstArg;
+      assert.notEqual(sdkRegistrationConfig, null);
+
+      const propagator: TextMapPropagator | null | undefined =
+        sdkRegistrationConfig.propagator;
+      assert.notEqual(propagator, null);
+
+      const actualPropagatorFields: string[] | undefined = propagator?.fields();
+      assert.notEqual(actualPropagatorFields, null);
+      assert.deepEqual(actualPropagatorFields, expectedPropagatorFields);
+    };
+
+    it('is configured by default', () => {
+      // by default, 'W3CTraceContextPropagator' and 'W3CBaggagePropagator' propagators are added.
+      // - 'traceparent' and 'tracestate' fields are used by the 'W3CTraceContextPropagator'
+      // - 'baggage' field is used by the 'W3CBaggagePropagator'
+      testConfiguredPropagator([], ['traceparent', 'tracestate', 'baggage']);
+    });
+
+    it('is configured to w3c-trace-context by env var', () => {
+      // 'traceparent' and 'tracestate' fields are used by the 'W3CTraceContextPropagator'
+      testConfiguredPropagator(['tracecontext'], ['traceparent', 'tracestate']);
+    });
+
+    it('is configured to w3c-baggage by env var', () => {
+      // 'baggage' field is used by the 'W3CBaggagePropagator'
+      testConfiguredPropagator(['baggage'], ['baggage']);
+    });
+
+    it('is configured to xray by env var', () => {
+      // 'x-amzn-trace-id' field is used by the 'AWSXRayPropagator'
+      testConfiguredPropagator(['xray'], ['x-amzn-trace-id']);
+    });
+
+    it('is configured to xray-lambda by env var', () => {
+      // 'x-amzn-trace-id' field is used by the 'AWSXRayLambdaPropagator'
+      testConfiguredPropagator(['xray'], ['x-amzn-trace-id']);
+    });
+
+    it('is configured by unsupported propagator', () => {
+      // in case of unsupported propagator, warning log is printed and empty propagator array is returned
+      testConfiguredPropagator(['jaeger'], []);
     });
   });
 });

--- a/nodejs/packages/layer/test/wrapper.spec.ts
+++ b/nodejs/packages/layer/test/wrapper.spec.ts
@@ -1,8 +1,16 @@
-import type { AwsSdkInstrumentationConfig } from '@opentelemetry/instrumentation-aws-sdk';
-import { SDKRegistrationConfig } from '@opentelemetry/sdk-trace-base';
-import { TextMapPropagator } from '@opentelemetry/api';
-
 import { wrap, unwrap } from '../src/wrapper';
+
+import {
+  defaultTextMapGetter,
+  ROOT_CONTEXT,
+  TextMapPropagator,
+  trace,
+  TraceFlags,
+} from '@opentelemetry/api';
+import type { AwsSdkInstrumentationConfig } from '@opentelemetry/instrumentation-aws-sdk';
+import { TRACE_PARENT_HEADER } from '@opentelemetry/core';
+import { AWSXRAY_TRACE_ID_HEADER } from '@opentelemetry/propagator-aws-xray';
+import { SDKRegistrationConfig } from '@opentelemetry/sdk-trace-base';
 
 import { stub } from 'sinon';
 import assert from 'assert';
@@ -69,6 +77,29 @@ describe('wrapper', () => {
       assert.deepEqual(actualPropagatorFields, expectedPropagatorFields);
     };
 
+    const setAndGetConfiguredPropagator = (
+      propagatorNames: string[],
+    ): TextMapPropagator => {
+      if (propagatorNames && propagatorNames.length) {
+        process.env.OTEL_PROPAGATORS = propagatorNames.join(',');
+      }
+
+      const configureSdkRegistrationStub = stub().returnsArg(0);
+      global.configureSdkRegistration = configureSdkRegistrationStub;
+      wrap();
+      assert(configureSdkRegistrationStub.calledOnce);
+
+      const sdkRegistrationConfig: SDKRegistrationConfig =
+        configureSdkRegistrationStub.getCall(0).firstArg;
+      assert.notEqual(sdkRegistrationConfig, null);
+
+      const propagator: TextMapPropagator | null | undefined =
+        sdkRegistrationConfig.propagator;
+      assert.notEqual(propagator, null);
+
+      return propagator!;
+    };
+
     it('is configured by default', () => {
       // by default, 'W3CTraceContextPropagator' and 'W3CBaggagePropagator' propagators are added.
       // - 'traceparent' and 'tracestate' fields are used by the 'W3CTraceContextPropagator'
@@ -99,6 +130,53 @@ describe('wrapper', () => {
     it('is configured by unsupported propagator', () => {
       // in case of unsupported propagator, warning log is printed and empty propagator array is returned
       testConfiguredPropagator(['jaeger'], []);
+    });
+
+    it('is configured in correct order', () => {
+      const W3C_TRACE_ID = '5b8aa5a2d2c872e8321cf37308d69df2';
+      const W3C_SPAN_ID = '051581bf3cb55c13';
+      const AWS_XRAY_TRACE_ID = '8a3c60f7-d188f8fa79d48a391a778fa6';
+      const AWS_XRAY_SPAN_ID = '53995c3f42cd8ad8';
+      const carrier = {
+        [TRACE_PARENT_HEADER]: `00-${W3C_TRACE_ID}-${W3C_SPAN_ID}-01`,
+        [AWSXRAY_TRACE_ID_HEADER]: `Root=1-${AWS_XRAY_TRACE_ID};Parent=${AWS_XRAY_SPAN_ID};Sampled=1`,
+      };
+
+      const propagator1: TextMapPropagator = setAndGetConfiguredPropagator([
+        'tracecontext',
+        'xray',
+      ]);
+      const extractedSpanContext1 = trace
+        .getSpan(
+          propagator1.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter),
+        )
+        ?.spanContext();
+      // Last one overwrites, so we will see the context extracted from the last propagator (xray)
+      assert.deepStrictEqual(extractedSpanContext1, {
+        traceId: AWS_XRAY_TRACE_ID.replace('-', ''),
+        spanId: AWS_XRAY_SPAN_ID,
+        isRemote: true,
+        traceFlags: TraceFlags.SAMPLED,
+      });
+
+      unwrap();
+
+      const propagator2: TextMapPropagator = setAndGetConfiguredPropagator([
+        'xray',
+        'tracecontext',
+      ]);
+      const extractedSpanContext2 = trace
+        .getSpan(
+          propagator2.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter),
+        )
+        ?.spanContext();
+      // Last one overwrites, so we will see the context extracted from the last propagator (tracecontext)
+      assert.deepStrictEqual(extractedSpanContext2, {
+        traceId: W3C_TRACE_ID,
+        spanId: W3C_SPAN_ID,
+        isRemote: true,
+        traceFlags: TraceFlags.SAMPLED,
+      });
     });
   });
 });


### PR DESCRIPTION
and additionally, this PR
- drops `@opentelemetry/sdk-trace-node` to be not dependent to the `@opentelemetry/propagator-b3` and `@opentelemetry/propagator-jaeger` propagator packages.
- and so (as a result of dropping `@opentelemetry/sdk-trace-node`  dependency) expands the required types can be passed to the `configureTracerProvider` and `configureTracer` functions. Since this is type expansion, it should not break backward compatibility, because lower types (`NodeTraceProvider` and `NodeTracerConfig`) can still be passed to these functions as is.