### PR TITLE
build(check-links): remove unnecessary npm install for check-links workflow

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,4 +1,4 @@
-name: check-links
+name: "Link Check"
 on:
   push:
     branches: [main]
@@ -33,9 +33,6 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
-
-      - name: Install markdown-link-check
-        run: npm install
 
       - name: Run markdown-link-check
         run: |


### PR DESCRIPTION
This was added by accident, but if the workflow is using npx, it will download the dependency automatically. There is also no `package.json` at the root of the repository either, which is causing errors in some PRs.