### PR TITLE
feat(nodejs): remove non-generic instrumentations from defaults

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -47,11 +47,7 @@ import {
 import { AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
 import { AWSXRayLambdaPropagator } from '@opentelemetry/propagator-aws-xray-lambda';
 
-const defaultInstrumentationList = [
-  'dns',
-  'http',
-  'net',
-];
+const defaultInstrumentationList = ['dns', 'http', 'net'];
 
 const propagatorMap = new Map<string, () => TextMapPropagator>([
   ['tracecontext', () => new W3CTraceContextPropagator()],
@@ -93,7 +89,7 @@ declare global {
   function configureLoggerProvider(loggerProvider: unknown): void;
 }
 
-function getActiveInstumentations(): Set<string> {
+function getActiveInstrumentations(): Set<string> {
   let enabledInstrumentations: string[] = defaultInstrumentationList;
   if (process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS) {
     enabledInstrumentations =
@@ -114,7 +110,7 @@ function getActiveInstumentations(): Set<string> {
 
 async function defaultConfigureInstrumentations() {
   const instrumentations = [];
-  const activeInstrumentations = getActiveInstumentations();
+  const activeInstrumentations = getActiveInstrumentations();
   if (activeInstrumentations.has('amqplib')) {
     const { AmqplibInstrumentation } = await import(
       '@opentelemetry/instrumentation-amqplib'

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -49,18 +49,8 @@ import { AWSXRayLambdaPropagator } from '@opentelemetry/propagator-aws-xray-lamb
 
 const defaultInstrumentationList = [
   'dns',
-  'express',
-  'graphql',
-  'grpc',
-  'hapi',
   'http',
-  'ioredis',
-  'koa',
-  'mongodb',
-  'mysql',
   'net',
-  'pg',
-  'redis',
 ];
 
 const propagatorMap = new Map<string, () => TextMapPropagator>([


### PR DESCRIPTION
This PR reduces the amount of default instrumentations. These are the instrumentations that are initialized by default when a user does not set the `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable on their lambda function.

The current defaults include a lot of instrumentations that are not generic. e.g. the `express` instrumentation is only useful to users who use the `express.js` framework in their lambda, but is currently part of the defaults.

To start I have reduced the list of defaults to contain:
```
dns
http
net
```
Having `http` instrumentation seems like a sensible default, as it is used under the hood by many other packages.

What concerns `dns` and `net` instrumentation, I can see a good case for removing those from the defaults as well. 
- `dns`: Do we need dns lookup etc spans by default?
- `net`: Do we need tcp level spans by default?
I'm personally leaning towards removing these from defaults as well. Any input here is appreciated!

fixes #1735