### PR TITLE
Update README.md

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -84,5 +84,4 @@ You'll find the generated layer zip file at `./packages/layer/build/layer.zip`.
 Sample applications are provided to show usage of the above layer.
 
 - Application using AWS SDK - shows using the wrapper with an application using AWS SDK without code change.
-  - [Using layer built from source](./integration-tests/aws-sdk)
   - [WIP] [Using OTel Public Layer](./sample-apps/aws-sdk) 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -8,7 +8,7 @@ To use, add the layer to your function configuration and then set `AWS_LAMBDA_EX
 ## Configuring auto instrumentation
 
 [AWS SDK v3 instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk)
-is loaded automatically by default.
+is included and loaded automatically by default.
 A subset of instrumentations from the [OTEL auto-instrumentations-node metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node)
 are also included.
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -9,26 +9,44 @@ To use, add the layer to your function configuration and then set `AWS_LAMBDA_EX
 
 [AWS SDK v3 instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk)
 is loaded automatically by default.
-The instrumentations from the [OTEL auto-instrumentations-node metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node)
-are also included, except for `cucumber, generic-pool, lru-memoizer`.
+A subset of instrumentations from the [OTEL auto-instrumentations-node metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node)
+are also included.
 
-Following instrumentations from the metapackage are automatically loaded by default:
-- `dns`
-- `express`
-- `graphql`
-- `grpc`
-- `hapi`
-- `http`
-- `ioredis`
-- `koa`
-- `mongodb`
-- `mysql`
-- `net`
-- `pg`
-- `redis`
+Following instrumentations from the metapackage are included:
+- `amqplib`
+- `bunyan`
+- `cassandra-driver`
+- `connect`
+- `dataloader`
+- `dns` *- default*
+- `express` *- default*
+- `fs`
+- `graphql` *- default*
+- `grpc` *- default*
+- `hapi` *- default*
+- `http` *- default*
+- `ioredis` *- default*
+- `kafkajs`
+- `knex`
+- `koa` *- default*
+- `memcached`
+- `mongodb` *- default*
+- `mongoose`
+- `mysql` *- default*
+- `mysql2`
+- `nestjs-core`
+- `net` *- default*
+- `pg` *- default*
+- `pino`
+- `redis` *- default*
+- `restify`
+- `socket.io`
+- `undici`
+- `winston`
 
+Instrumentations annotated with "*- default*" are loaded by default.
 To only load specific instrumentations, specify the `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable in the lambda configuration.
-This disables all the defaults mentioned above, and only enable the ones you specify. Selectively disabling instrumentations from the defaults is also possible with the `OTEL_NODE_DISABLED_INSTRUMENTATIONS` environment variable.
+This disables all the defaults, and only enables the ones you specify. Selectively disabling instrumentations from the defaults is also possible with the `OTEL_NODE_DISABLED_INSTRUMENTATIONS` environment variable.
 
 The environment variables should be set to a comma-separated list of the instrumentation package names without the 
 `@opentelemetry/instrumentation-` prefix.

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -5,8 +5,42 @@ the `AWS_LAMBDA_EXEC_WRAPPER` environment variable will initialize OpenTelemetry
 
 To use, add the layer to your function configuration and then set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-handler`.
 
-[AWS SDK v2 instrumentation](https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk) is also
-included and loaded automatically if you use the AWS SDK v2.
+## Configuring auto instrumentation
+
+[AWS SDK v3 instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk)
+is loaded automatically by default.
+The instrumentations from the [OTEL auto-instrumentations-node metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node)
+are also included, except for `cucumber, generic-pool, lru-memoizer`.
+
+Following instrumentations from the metapackage are automatically loaded by default:
+- `dns`
+- `express`
+- `graphql`
+- `grpc`
+- `hapi`
+- `http`
+- `ioredis`
+- `koa`
+- `mongodb`
+- `mysql`
+- `net`
+- `pg`
+- `redis`
+
+To only load specific instrumentations, specify the `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable in the lambda configuration.
+This disables all the defaults mentioned above, and only enable the ones you specify. Selectively disabling instrumentations from the defaults is also possible with the `OTEL_NODE_DISABLED_INSTRUMENTATIONS` environment variable.
+
+The environment variables should be set to a comma-separated list of the instrumentation package names without the 
+`@opentelemetry/instrumentation-` prefix.
+
+For example, to enable only `@opentelemetry/instrumentation-http` and `@opentelemetry/instrumentation-undici`:
+```shell
+OTEL_NODE_ENABLED_INSTRUMENTATIONS="http,undici"
+```
+To disable only `@opentelemetry/instrumentation-net`:
+```shell
+OTEL_NODE_DISABLED_INSTRUMENTATIONS="net"
+```
 
 ## Building
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -45,6 +45,7 @@ Following instrumentations from the metapackage are included:
 - `winston`
 
 Instrumentations annotated with "*- default*" are loaded by default.
+
 To only load specific instrumentations, specify the `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable in the lambda configuration.
 This disables all the defaults, and only enables the ones you specify. Selectively disabling instrumentations from the defaults is also possible with the `OTEL_NODE_DISABLED_INSTRUMENTATIONS` environment variable.
 


### PR DESCRIPTION
Added nodejs instrumentation section to highlight possibility of selectively enabling/disabling instrumentation. Removed outdated info with regards to aws sdk instrumentation. Also included info on which of the instrumentations are supported, as well as which ones are enabled by default.