### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         # If you add a python version here, please make sure that the collector/Makefile publish and publish-layer targets
         # get updated as well
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout this repo

--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -122,7 +122,7 @@ jobs:
       artifact-name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip
       layer-name: opentelemetry-collector
       architecture: ${{ matrix.architecture }}
-      runtimes: "nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.8 python3.9 python3.10 python3.11 python3.12"
+      runtimes: "nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13"
       release-group: prod
       aws_region: ${{ matrix.aws_region }}
       role-arn: ${{ github.event.inputs.role-arn }}

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -47,12 +47,12 @@ package: build
 
 .PHONY: publish
 publish:
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.8 python3.9 python3.10 python3.11 python3.12 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 --query 'LayerVersionArn' --output text
 
 .PHONY: publish-layer
 publish-layer: package
 	@echo Publishing collector extension layer...
-	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.8 python3.9 python3.10 python3.11 python3.12 --query 'LayerVersionArn' --output text
+	aws lambda publish-layer-version --layer-name $(LAYER_NAME) --zip-file fileb://$(BUILD_SPACE)/opentelemetry-collector-layer-$(GOARCH).zip --compatible-runtimes nodejs16.x nodejs18.x nodejs20.x nodejs22.x java11 java17 java21 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 --query 'LayerVersionArn' --output text
 	@echo OpenTelemetry Collector layer published.
 
 .PHONY: set-otelcol-version

--- a/python/sample-apps/template.yml
+++ b/python/sample-apps/template.yml
@@ -47,5 +47,6 @@ Resources:
         - python3.10
         - python3.11
         - python3.12
+        - python3.13
     Metadata:
       BuildMethod: makefile

--- a/python/src/otel/Dockerfile
+++ b/python/src/otel/Dockerfile
@@ -1,4 +1,4 @@
-ARG runtime=python3.12
+ARG runtime=python3.13
 
 FROM public.ecr.aws/sam/build-${runtime}
 

--- a/python/src/template.yml
+++ b/python/src/template.yml
@@ -19,5 +19,6 @@ Resources:
         - python3.10
         - python3.11
         - python3.12
+        - python3.13
     Metadata:
       BuildMethod: makefile


### PR DESCRIPTION
### Context
Add support for `Python3.13`

### Testing
- I ran this command `bash run.sh -n test-otel-313 -b true` and walked through the zip file.
- I can do further testing by spinning up a Lambda instance (Please let me know)

The reason I created this PR: https://github.com/aws-observability/aws-otel-lambda/issues/1080

closes #1755 