### PR TITLE
NodeJS: Replace `SimpleLogRecordProcessor` by `BatchLogRecordProcessor`

### DIFF
--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -449,7 +449,7 @@ async function initializeLoggerProvider(
   }
 
   const { logs } = await import('@opentelemetry/api-logs');
-  const { LoggerProvider, BatchLogRecordProcessor, ConsoleLogRecordExporter } =
+  const { LoggerProvider, BatchLogRecordProcessor, SimpleLogRecordProcessor, ConsoleLogRecordExporter } =
     await import('@opentelemetry/sdk-logs');
   const { OTLPLogExporter } = await import(
     '@opentelemetry/exporter-logs-otlp-http'
@@ -472,7 +472,7 @@ async function initializeLoggerProvider(
   // Logging for debug
   if (logLevel === DiagLogLevel.DEBUG) {
     loggerProvider.addLogRecordProcessor(
-      new BatchLogRecordProcessor(new ConsoleLogRecordExporter()),
+      new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
     );
   }
 

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -449,7 +449,7 @@ async function initializeLoggerProvider(
   }
 
   const { logs } = await import('@opentelemetry/api-logs');
-  const { LoggerProvider, SimpleLogRecordProcessor, ConsoleLogRecordExporter } =
+  const { LoggerProvider, BatchLogRecordProcessor, ConsoleLogRecordExporter } =
     await import('@opentelemetry/sdk-logs');
   const { OTLPLogExporter } = await import(
     '@opentelemetry/exporter-logs-otlp-http'
@@ -464,7 +464,7 @@ async function initializeLoggerProvider(
     configureLoggerProvider(loggerProvider);
   } else {
     loggerProvider.addLogRecordProcessor(
-      new SimpleLogRecordProcessor(logExporter),
+      new BatchLogRecordProcessor(logExporter),
     );
     logs.setGlobalLoggerProvider(loggerProvider);
   }
@@ -472,7 +472,7 @@ async function initializeLoggerProvider(
   // Logging for debug
   if (logLevel === DiagLogLevel.DEBUG) {
     loggerProvider.addLogRecordProcessor(
-      new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
+      new BatchLogRecordProcessor(new ConsoleLogRecordExporter()),
     );
   }
 

--- a/nodejs/packages/layer/src/wrapper.ts
+++ b/nodejs/packages/layer/src/wrapper.ts
@@ -449,8 +449,12 @@ async function initializeLoggerProvider(
   }
 
   const { logs } = await import('@opentelemetry/api-logs');
-  const { LoggerProvider, BatchLogRecordProcessor, SimpleLogRecordProcessor, ConsoleLogRecordExporter } =
-    await import('@opentelemetry/sdk-logs');
+  const {
+    LoggerProvider,
+    BatchLogRecordProcessor,
+    SimpleLogRecordProcessor,
+    ConsoleLogRecordExporter,
+  } = await import('@opentelemetry/sdk-logs');
   const { OTLPLogExporter } = await import(
     '@opentelemetry/exporter-logs-otlp-http'
   );


### PR DESCRIPTION
Fixes #1798 

`SimpleLogRecordProcessor` has a [concurrency limit of 30](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/otlp-exporter-base/src/otlp-export-delegate.ts#L64) simultaneous export promises. After hitting this limit, the Processor throws the error `Error: Concurrent export limit reached`. 

To avoid the error during heavy logging, we can use [BatchLogRecordProcessor](https://github.com/open-telemetry/opentelemetry-js/blob/db0616fb3738f02ac45c43126ada0c9e5e24bbb3/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts#L21). 

`BatchLogRecordProcessor` can already be configured via [env vars](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts#L51), which is good for lambda layer:
* OTEL_BLRP_MAX_EXPORT_BATCH_SIZE
* OTEL_BLRP_MAX_QUEUE_SIZE
* OTEL_BLRP_SCHEDULE_DELAY 
* OTEL_BLRP_EXPORT_TIMEOUT

