### PR TITLE
feat: add explicit read-only permission

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -20,6 +20,9 @@ env:
   # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/.github/workflows/test.yml#L9
   CORE_REPO_SHA: v1.19.0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-shellcheck.yml
+++ b/.github/workflows/ci-shellcheck.yml
@@ -2,6 +2,9 @@ name: "Continuous Build (shellcheck)"
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-terraform-syntax:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '37 10 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
**Context:** 
This PR helps increasing the security score here: https://clomonitor.io/projects/cncf/open-telemetry#opentelemetry-lambda

**Content of this PR**
This PR fixes token permission by setting them `read-only` by default. See clomonitor check definition here: https://clomonitor.io/docs/topics/checks/#token-permissions-from-openssf-scorecard

This will resolve this failing check:
![Screenshot 2025-05-22 at 12 35 07 AM](https://github.com/user-attachments/assets/25c461c1-f829-4f94-8bdb-ce5f0027302c)

Full error/warning message:
```
Info: topLevel permissions set to 'read-all': .github/workflows/check-links.yaml:11
Warn: no topLevel permission defined: .github/workflows/ci-collector.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/ci-collector.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: no topLevel permission defined: .github/workflows/ci-nodejs.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/ci-nodejs.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: no topLevel permission defined: .github/workflows/ci-python.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/ci-python.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: no topLevel permission defined: .github/workflows/ci-shellcheck.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/ci-shellcheck.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: no topLevel permission defined: .github/workflows/ci-terraform.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/ci-terraform.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: no topLevel permission defined: .github/workflows/codeql.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/codeql.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Info: jobLevel 'actions' permission set to 'read': .github/workflows/codeql.yml:34
Info: jobLevel 'contents' permission set to 'read': .github/workflows/codeql.yml:35
Info: topLevel 'contents' permission set to 'read': .github/workflows/fossa.yml:9
Info: topLevel 'contents' permission set to 'read': .github/workflows/layer-publish.yml:46
Info: topLevel permissions set to 'read-all': .github/workflows/ossf-scorecard.yml:11
Warn: no topLevel permission defined: .github/workflows/publish-layer-collector.yml:1: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/publish-layer-collector.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-layer-collector.yml:11: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/release-layer-collector.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-layer-java.yml:11: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/release-layer-java.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-layer-nodejs.yml:11: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/release-layer-nodejs.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-layer-python.yml:11: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/release-layer-python.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-layer-ruby.yml:11: Visit https://app.stepsecurity.io/secureworkflow/open-telemetry/opentelemetry-lambda/release-layer-ruby.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead. (Low effort)
Info: no jobLevel write permissions found
```