### PR TITLE
feat: remove hardcoded version of go in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-collector.yml
+++ b/.github/workflows/ci-collector.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '~1.21.9'
+          go-version-file: collector/go.mod
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '~1.21.9'
+          go-version-file: collector/go.mod
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '~1.21.9'
+          go-version-file: collector/go.mod
       - name: Build Collector
         run: |
           if [[ -n "${{ inputs.build-tags }}" ]]; then

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '^1.24.2'
+          go-version-file: collector/go.mod
       - name: build
         run: make -C collector package GOARCH=${{ matrix.architecture }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -34,7 +34,7 @@ clean:
 
 .PHONY: build
 build: clean set-otelcol-version
-	@echo Building otel collector extension, go version = $(shell go version)
+	@echo Building otel collector extension, $(shell go version)
 	mkdir -p $(BUILD_SPACE)/extensions
 	GOOS=linux GOARCH=$(GOARCH) $(GOBUILD) $(LDFLAGS) -o $(BUILD_SPACE)/extensions .
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -34,13 +34,12 @@ clean:
 
 .PHONY: build
 build: clean set-otelcol-version
-	@echo Building otel collector extension
+	@echo Building otel collector extension, go version = $(shell go version)
 	mkdir -p $(BUILD_SPACE)/extensions
 	GOOS=linux GOARCH=$(GOARCH) $(GOBUILD) $(LDFLAGS) -o $(BUILD_SPACE)/extensions .
 
 .PHONY: package
 package: build
-	@echo Builing: go version = $(shell go version)
 	@echo Package zip file for collector extension layer
 	mkdir -p $(BUILD_SPACE)/collector-config
 	cp config* $(BUILD_SPACE)/collector-config

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -40,6 +40,7 @@ build: clean set-otelcol-version
 
 .PHONY: package
 package: build
+	@echo Builing: go version = $(shell go version)
 	@echo Package zip file for collector extension layer
 	mkdir -p $(BUILD_SPACE)/collector-config
 	cp config* $(BUILD_SPACE)/collector-config


### PR DESCRIPTION
## Context
This PR fixes the first todo of https://github.com/open-telemetry/opentelemetry-lambda/issues/1838
It uses the documented `go-version-file` instead of an hardcoded value (doc: https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file)

Even if the go version is printed out in the output of `actions/setup-go` I think it's useful to print it in the build target (see Makefile) for potential debugging purpose, totally fine to remove it if needed.

## Test 
Tested on my fork ✅
1. Output of `actions/setup-go`
<img width="1073" alt="Screenshot 2025-05-31 at 10 02 14 AM" src="https://github.com/user-attachments/assets/5c23fda6-07cf-4bc4-a9c5-73a01a7650d1" />

2. Output of the go version log in `make build`
<img width="762" alt="Screenshot 2025-05-31 at 10 07 10 AM" src="https://github.com/user-attachments/assets/1b9e25d1-47d0-4ec3-8917-280460dda719" />

