### PR TITLE
chore(nodejs) remove context-async-hooks

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -15363,7 +15363,6 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.202.0",
-        "@opentelemetry/context-async-hooks": "^2.0.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.202.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.202.0",

--- a/nodejs/packages/layer/package.json
+++ b/nodejs/packages/layer/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.202.0",
-    "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.202.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.202.0",


### PR DESCRIPTION
This package was added in this PR, but it appears to be unused now.
https://github.com/open-telemetry/opentelemetry-lambda/pull/1664

https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-lambda%20context-async-hooks&type=code
