### PR TITLE
build: update collector go version to 1.24.4 and fix vulnerabilities

### DIFF
--- a/collector/go.mod
+++ b/collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector
 
-go 1.24.2
+go 1.24.4
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents => ./lambdacomponents
 

--- a/collector/internal/tools/go.mod
+++ b/collector/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/internal/tools
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/collector/lambdacomponents/go.mod
+++ b/collector/lambdacomponents/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.129.0

--- a/collector/lambdalifecycle/go.mod
+++ b/collector/lambdalifecycle/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle
 
-go 1.24.2
+go 1.24.4

--- a/collector/processor/coldstartprocessor/go.mod
+++ b/collector/processor/coldstartprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/cespare/xxhash v1.1.0

--- a/collector/processor/decoupleprocessor/go.mod
+++ b/collector/processor/decoupleprocessor/go.mod
@@ -2,7 +2,7 @@ module github.com/open-telemetry/opentelemetry-lambda/collector/processor/decoup
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle => ../../lambdalifecycle
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/open-telemetry/opentelemetry-lambda/collector/lambdalifecycle v0.0.0-00010101000000-000000000000

--- a/collector/receiver/telemetryapireceiver/go.mod
+++ b/collector/receiver/telemetryapireceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver
 
-go 1.24.2
+go 1.24.4
 
 replace github.com/open-telemetry/opentelemetry-lambda/collector => ../../
 

--- a/go/sample-apps/function/go.mod
+++ b/go/sample-apps/function/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-lambda/go/sample-apps/function
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/aws/aws-lambda-go v1.49.0


### PR DESCRIPTION
```
 govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-3751
    Sensitive headers not cleared on cross-origin redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3751
  Standard library
    Found in: net/http@go1.24.2
    Fixed in: net/http@go1.24.4
    Example traces found:
      #1: internal/extensionapi/client.go:179:30: extensionapi.Client.doRequest calls http.Client.Do

Vulnerability #2: GO-2025-3750
    Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
    syscall
  More info: https://pkg.go.dev/vuln/GO-2025-3750
  Standard library
    Found in: os@go1.24.2
    Fixed in: os@go1.24.4
    Platforms: windows
    Example traces found:
      #1: internal/telemetryapi/client.go:87:2: telemetryapi.Client.Subscribe calls http.http2transportResponseBody.Close, which eventually calls os.Create
      #2: internal/telemetryapi/listener.go:104:28: telemetryapi.Start calls http.Server.Serve, which eventually calls os.CreateTemp
      #3: internal/collector/collector.go:120:22: collector.Start calls otelcol.Collector.Run, which eventually calls os.File.Readdir
      #4: internal/telemetryapi/listener.go:104:28: telemetryapi.Start calls http.Server.Serve, which eventually calls os.File.Readdirnames
      #5: internal/telemetryapi/client.go:24:2: telemetryapi.init calls os.init, which calls os.Getwd
      #6: internal/collector/collector.go:120:22: collector.Start calls otelcol.Collector.Run, which eventually calls os.Lstat
      #7: internal/collector/collector.go:120:22: collector.Start calls otelcol.Collector.Run, which eventually calls os.MkdirAll
      #8: internal/telemetryapi/client.go:24:2: telemetryapi.init calls os.init, which calls os.NewFile
      #9: internal/telemetryapi/client.go:87:2: telemetryapi.Client.Subscribe calls http.http2requestBody.Close, which eventually calls os.Open
      #10: internal/telemetryapi/client.go:87:2: telemetryapi.Client.Subscribe calls http.http2transportResponseBody.Close, which eventually calls os.OpenFile
      #11: internal/extensionapi/client.go:179:30: extensionapi.Client.doRequest calls http.Client.Do, which eventually calls os.ReadFile
      #12: internal/telemetryapi/listener.go:104:28: telemetryapi.Start calls http.Server.Serve, which eventually calls os.Remove
      #13: internal/collector/collector.go:120:22: collector.Start calls otelcol.Collector.Run, which eventually calls os.Rename
      #14: internal/collector/collector.go:120:22: collector.Start calls otelcol.Collector.Run, which eventually calls os.Stat
      #15: internal/telemetryapi/client.go:87:2: telemetryapi.Client.Subscribe calls http.http2transportResponseBody.Close, which eventually calls os.Symlink
      #16: internal/telemetryapi/client.go:24:2: telemetryapi.init calls os.init, which eventually calls syscall.Open

Vulnerability #3: GO-2025-3749
    Usage of ExtKeyUsageAny disables policy validation in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3749
  Standard library
    Found in: crypto/x509@go1.24.2
    Fixed in: crypto/x509@go1.24.4
    Example traces found:
      #1: internal/telemetryapi/listener.go:104:28: telemetryapi.Start calls http.Server.Serve, which eventually calls x509.Certificate.Verify

Your code is affected by 3 vulnerabilities from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 2
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```