### PR TITLE
docs: fix links

### DIFF
--- a/collector/processor/coldstartprocessor/README.md
+++ b/collector/processor/coldstartprocessor/README.md
@@ -29,4 +29,4 @@ processors:
 ```
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
-[extension]: https://github.com/open-telemetry/opentelemetry-lambda/collector
+[extension]: https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector

--- a/collector/processor/decoupleprocessor/README.md
+++ b/collector/processor/decoupleprocessor/README.md
@@ -35,5 +35,5 @@ processors:
 ```
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#development
-[extension]: https://github.com/open-telemetry/opentelemetry-lambda/collector
+[extension]: https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector
 [lifecycle]: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html#runtimes-extensions-api-lifecycle

--- a/collector/receiver/telemetryapireceiver/README.md
+++ b/collector/receiver/telemetryapireceiver/README.md
@@ -37,4 +37,4 @@ receivers:
 ```
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
-[extension]: https://github.com/open-telemetry/opentelemetry-lambda/collector
+[extension]: https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -7,9 +7,9 @@ To use, add the layer to your function configuration and then set `AWS_LAMBDA_EX
 
 ## Configuring auto instrumentation
 
-[AWS SDK v3 instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk)
+[AWS SDK v3 instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-aws-sdk)
 is included and loaded automatically by default.
-A subset of instrumentations from the [OTEL auto-instrumentations-node metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node)
+A subset of instrumentations from the [OTEL auto-instrumentations-node metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/auto-instrumentations-node)
 are also included.
 
 Following instrumentations from the metapackage are included:
@@ -49,7 +49,7 @@ Instrumentations annotated with "*- default*" are loaded by default.
 To only load specific instrumentations, specify the `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable in the lambda configuration.
 This disables all the defaults, and only enables the ones you specify. Selectively disabling instrumentations from the defaults is also possible with the `OTEL_NODE_DISABLED_INSTRUMENTATIONS` environment variable.
 
-The environment variables should be set to a comma-separated list of the instrumentation package names without the 
+The environment variables should be set to a comma-separated list of the instrumentation package names without the
 `@opentelemetry/instrumentation-` prefix.
 
 For example, to enable only `@opentelemetry/instrumentation-http` and `@opentelemetry/instrumentation-undici`:
@@ -84,4 +84,4 @@ You'll find the generated layer zip file at `./packages/layer/build/layer.zip`.
 Sample applications are provided to show usage of the above layer.
 
 - Application using AWS SDK - shows using the wrapper with an application using AWS SDK without code change.
-  - [WIP] [Using OTel Public Layer](./sample-apps/aws-sdk) 
+  - [WIP] [Using OTel Public Layer](./sample-apps/aws-sdk)


### PR DESCRIPTION
The links to opentelemetry-js-contrib.git changed due to
https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2928

---

I tested locally with:

```
lychee --verbose --config .github/lychee.toml **/*.md
```

The other links (those *not* related to the opentelemetry-js-contrib.git change) were ... broken for a while I guess? I didn't dig into the history there.