### PR TITLE
Add build attestations to all uploaded/released artifacts.

### DIFF
--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -54,7 +54,6 @@ on:
 
 permissions:
   contents: read
-  attestations: write
 
 jobs:
   prepare-build-jobs:
@@ -75,6 +74,10 @@ jobs:
   build-layer:
     needs: prepare-build-jobs
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
     strategy:
       matrix: ${{ fromJSON(needs.prepare-build-jobs.outputs.build_jobs) }}
     steps:

--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -47,11 +47,7 @@ on:
         description: 'Build tags to customize collector build'
         required: false
         type: string
-      codesigning-profile:
-        description: 'The AWS Signing Profile for the layers'
-        required: false
-        type: string
-
+      
 permissions:
   contents: read
 

--- a/.github/workflows/publish-layer-collector.yml
+++ b/.github/workflows/publish-layer-collector.yml
@@ -47,9 +47,14 @@ on:
         description: 'Build tags to customize collector build'
         required: false
         type: string
+      codesigning-profile:
+        description: 'The AWS Signing Profile for the layers'
+        required: false
+        type: string
 
 permissions:
   contents: read
+  attestations: write
 
 jobs:
   prepare-build-jobs:
@@ -89,6 +94,10 @@ jobs:
           fi
           echo "Build tags: $BUILDTAGS"
           make -C collector package GOARCH=${{ matrix.architecture }} BUILDTAGS=$BUILDTAGS
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: ${{ github.workspace }}/collector/build/opentelemetry-collector-layer-${{ matrix.architecture }}.zip
       - name: Upload Collector Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -39,6 +39,12 @@ jobs:
           go-version-file: collector/go.mod
       - name: build
         run: make -C collector package GOARCH=${{ matrix.architecture }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: ${{ github.workspace }}/collector/build/opentelemetry-collector-layer-${{ matrix.architecture }}.zip
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: opentelemetry-collector-layer-${{ matrix.architecture }}.zip

--- a/.github/workflows/release-layer-collector.yml
+++ b/.github/workflows/release-layer-collector.yml
@@ -22,7 +22,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-layer:
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     runs-on: ubuntu-latest
     needs: create-release
     strategy:

--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -22,7 +22,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-layer:
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     runs-on: ubuntu-latest
     needs: create-release
     outputs:

--- a/.github/workflows/release-layer-java.yml
+++ b/.github/workflows/release-layer-java.yml
@@ -44,12 +44,21 @@ jobs:
           cd java
           ./gradlew :layer-javaagent:assemble :layer-wrapper:assemble --scan --stacktrace
 
+      - name: Generate artifact attestation for javaagent
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: java/layer-javaagent/build/distributions/opentelemetry-javaagent-layer.zip
+      
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: Save javaagent layer to build
         with:
           name: opentelemetry-javaagent-layer.zip
           path: java/layer-javaagent/build/distributions/opentelemetry-javaagent-layer.zip
 
+      - name: Generate artifact attestation for javawrapper
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: java/layer-wrapper/build/distributions/opentelemetry-javawrapper-layer.zip
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: Save javawrapper layer to build
         with:

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -22,7 +22,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-layer:
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     runs-on: ubuntu-latest
     needs: create-release
     outputs:

--- a/.github/workflows/release-layer-nodejs.yml
+++ b/.github/workflows/release-layer-nodejs.yml
@@ -51,6 +51,10 @@ jobs:
         run: mv layer.zip opentelemetry-nodejs-layer.zip
         working-directory: nodejs/packages/layer/build
 
+      - name: Generate artifact attestation for nodejs-layer
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: nodejs/packages/layer/build/opentelemetry-nodejs-layer.zip
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: Save assembled layer to build
         with:

--- a/.github/workflows/release-layer-python.yml
+++ b/.github/workflows/release-layer-python.yml
@@ -22,7 +22,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-layer:
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     runs-on: ubuntu-latest
     needs: create-release
     outputs:

--- a/.github/workflows/release-layer-python.yml
+++ b/.github/workflows/release-layer-python.yml
@@ -57,6 +57,11 @@ jobs:
         run: |
           ls -al
         working-directory: python/src/build
+    
+      - name: Generate artifact attestation for python-layer
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: python/src/build/opentelemetry-python-layer.zip
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: Save assembled layer to build

--- a/.github/workflows/release-layer-ruby.yml
+++ b/.github/workflows/release-layer-ruby.yml
@@ -22,7 +22,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-layer:
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     runs-on: ubuntu-latest
     needs: create-release
     outputs:

--- a/.github/workflows/release-layer-ruby.yml
+++ b/.github/workflows/release-layer-ruby.yml
@@ -50,6 +50,11 @@ jobs:
           ls -al
         working-directory: ruby/src/build
 
+
+      - name: Generate artifact attestation for ruby-layer  
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  #v3.0.0
+        with:
+          subject-path: ruby/src/build/opentelemetry-ruby-layer.zip
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: Save assembled layer to build
         with:


### PR DESCRIPTION
As a step suggested in #1963 , add the GH attestations for binaries produced by the Github workflows on this repository, so that all artefacts generated as a result of the workflows have provenance checks.

It may be that more work needs to be done on deciding how to manage the lifecycle of historic attestations.

https://github.com/actions/attest-build-provenance