### PR TITLE
chore(actions): Upgrade java to version 17 for codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         distribution: corretto
-        java-version: '11'
+        java-version: '17'
       if: ${{ matrix.target.language == 'java' }}
 
     - name: Setup Gradle


### PR DESCRIPTION
The dependabot update for the spotless plugin in #1917 causes the codeql workflow to fail due to an incompatible java version. Since this new major 8.0.0 spotless requires java 17.